### PR TITLE
fix typo of `retryable` as the annotation of Spring Retryable. add st…

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/model/BranchStatus.java
+++ b/core/src/main/java/com/alibaba/fescar/core/model/BranchStatus.java
@@ -18,6 +18,9 @@ package com.alibaba.fescar.core.model;
 
 import com.alibaba.fescar.common.exception.ShouldNeverHappenException;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Status of branch transaction.
  */
@@ -41,31 +44,40 @@ public enum BranchStatus {
     // Commit logic is successfully done at phase two.
     PhaseTwo_Committed,
 
-    // Commit logic is failed but retriable.
-    PhaseTwo_CommitFailed_Retriable,
+    // Commit logic is failed but retryable.
+    PhaseTwo_CommitFailed_Retryable,
 
-    // Commit logic is failed and NOT retriable.
-    PhaseTwo_CommitFailed_Unretriable,
+    // Commit logic is failed and NOT retryable.
+    PhaseTwo_CommitFailed_Unretryable,
 
     // Rollback logic is successfully done at phase two.
     PhaseTwo_Rollbacked,
 
-    // Rollback logic is failed but retriable.
-    PhaseTwo_RollbackFailed_Retriable,
+    // Rollback logic is failed but retryable.
+    PhaseTwo_RollbackFailed_Retryable,
 
-    // Rollback logic is failed but NOT retriable.
-    PhaseTwo_RollbackFailed_Unretriable;
+    // Rollback logic is failed but NOT retryable.
+    PhaseTwo_RollbackFailed_Unretryable;
+
+    private static final Map<Integer, BranchStatus> map = new HashMap<>(values().length);
+
+    static {
+        for (BranchStatus status : values()) {
+            map.put(status.ordinal(), status);
+        }
+    }
 
     public static BranchStatus get(byte ordinal) {
         return get((int) ordinal);
     }
 
     public static BranchStatus get(int ordinal) {
-        for (BranchStatus branchStatus : BranchStatus.values()) {
-            if (branchStatus.ordinal() == ordinal) {
-                return branchStatus;
-            }
+        BranchStatus status = map.get(ordinal);
+
+        if (null == status) {
+            throw new ShouldNeverHappenException("Unknown BranchStatus[" + ordinal + "]");
         }
-        throw new ShouldNeverHappenException("Unknown BranchStatus[" + ordinal + "]");
+
+        return status;
     }
 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceManager.java
@@ -159,9 +159,9 @@ public class DataSourceManager implements ResourceManager {
             UndoLogManager.undo(dataSourceProxy, xid, branchId);
         } catch (TransactionException te) {
             if (te.getCode() == TransactionExceptionCode.BranchRollbackFailed_Unretriable) {
-                return BranchStatus.PhaseTwo_RollbackFailed_Unretriable;
+                return BranchStatus.PhaseTwo_RollbackFailed_Unretryable;
             } else {
-                return BranchStatus.PhaseTwo_RollbackFailed_Retriable;
+                return BranchStatus.PhaseTwo_RollbackFailed_Retryable;
             }
         }
         return BranchStatus.PhaseTwo_Rollbacked;

--- a/server/src/main/java/com/alibaba/fescar/server/coordinator/DefaultCore.java
+++ b/server/src/main/java/com/alibaba/fescar/server/coordinator/DefaultCore.java
@@ -158,7 +158,7 @@ public class DefaultCore implements Core {
                     case PhaseTwo_Committed:
                         globalSession.removeBranch(branchSession);
                         continue;
-                    case PhaseTwo_CommitFailed_Unretriable:
+                    case PhaseTwo_CommitFailed_Unretryable:
                         if (globalSession.canBeCommittedAsync()) {
                             LOGGER.error("By [" + branchStatus + "], failed to commit branch " + branchSession);
                             continue;
@@ -262,7 +262,7 @@ public class DefaultCore implements Core {
                         globalSession.removeBranch(branchSession);
                         LOGGER.error("Successfully rolled back branch " + branchSession);
                         continue;
-                    case PhaseTwo_RollbackFailed_Unretriable:
+                    case PhaseTwo_RollbackFailed_Unretryable:
                         GlobalStatus currentStatus = globalSession.getStatus();
                         if (currentStatus.name().startsWith("Timeout")) {
                             globalSession.changeStatus(GlobalStatus.TimeoutRollbackFailed);


### PR DESCRIPTION
Fix typo of `retryable` as the annotation of Spring Retryable. 
Add a static code block to init BranchStatus mapper to speed up get(int ordinal).