### PR TITLE
fix #127 remove redundant fileChannel.close() invoke

### DIFF
--- a/server/src/main/java/com/alibaba/fescar/server/store/FileTransactionStoreManager.java
+++ b/server/src/main/java/com/alibaba/fescar/server/store/FileTransactionStoreManager.java
@@ -177,7 +177,7 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
 
         } catch (IOException exx) {
         } finally {
-            closeFile(raf, null);
+            closeFile(raf);
         }
         return false;
     }
@@ -228,7 +228,7 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
                         recoverCurrOffset = fileChannel.position();
                     }
                 }
-                closeFile(raf, fileChannel);
+                closeFile(raf);
             } catch (IOException exx) {
                 LOGGER.error("file close error," + exx.getMessage());
             }
@@ -241,12 +241,8 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
         return file.getName().endsWith(HIS_DATA_FILENAME_POSTFIX);
     }
 
-    private void closeFile(RandomAccessFile raf, FileChannel fileChannel) {
+    private void closeFile(RandomAccessFile raf) {
         try {
-            if (null != fileChannel) {
-                fileChannel.close();
-                fileChannel = null;
-            }
             if (null != raf) {
                 raf.close();
                 raf = null;
@@ -353,7 +349,7 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
                     }
                 }
                 currFileChannel.force(true);
-                closeFile(currRaf, currFileChannel);
+                closeFile(currRaf);
                 Files.move(currDataFile.toPath(), new File(hisFullFileName).toPath(),
                     StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException exx) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
FileTransactionStoreManager#closeFile() method remove redundant fileChannel.close() invoke

### Ⅱ. Does this pull request fix one issue?
fix #127 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

