### PR TITLE
fix BranchStatus null,should register branch application id

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/model/ResourceManagerOutbound.java
+++ b/core/src/main/java/com/alibaba/fescar/core/model/ResourceManagerOutbound.java
@@ -23,7 +23,7 @@ import com.alibaba.fescar.core.exception.TransactionException;
  */
 public interface ResourceManagerOutbound {
 
-    Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys) throws
+    Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys,String branchApplicationId) throws
         TransactionException;
 
     void branchReport(String xid, long branchId, BranchStatus status, String applicationData) throws TransactionException;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/ConnectionProxy.java
@@ -67,7 +67,7 @@ public class ConnectionProxy extends AbstractConnectionProxy {
         // Just check lock without requiring lock by now.
         String lockKeys = buildLockKey(records);
         try {
-            DataSourceManager.get().branchRegister(BranchType.AT, getDataSourceProxy().getResourceId(), null, context.getXid(), lockKeys);
+            DataSourceManager.get().branchRegister(BranchType.AT, getDataSourceProxy().getResourceId(), null, context.getXid(), lockKeys,null);
         } catch (TransactionException e) {
             recognizeLockKeyConflictException(e);
         }
@@ -155,7 +155,7 @@ public class ConnectionProxy extends AbstractConnectionProxy {
 
     private void register() throws TransactionException {
         Long branchId = DataSourceManager.get().branchRegister(BranchType.AT, getDataSourceProxy().getResourceId(),
-                null, context.getXid(), context.buildLockKeys());
+                null, context.getXid(), context.buildLockKeys(),null);
         context.setBranchId(branchId);
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceManager.java
@@ -47,7 +47,7 @@ public class DataSourceManager implements ResourceManager {
     }
 
     @Override
-    public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys) throws TransactionException {
+    public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys,String branchApplicationId) throws TransactionException {
         try {
             BranchRegisterRequest request = new BranchRegisterRequest();
             request.setTransactionId(XID.getTransactionId(xid));

--- a/server/src/main/java/com/alibaba/fescar/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/com/alibaba/fescar/server/coordinator/DefaultCoordinator.java
@@ -111,7 +111,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler
         response.setTransactionId(request.getTransactionId());
         response.setBranchId(
             core.branchRegister(request.getBranchType(), request.getResourceId(), rpcContext.getClientId(),
-                XID.generateXID(request.getTransactionId()), request.getLockKey()));
+                XID.generateXID(request.getTransactionId()), request.getLockKey(),rpcContext.getApplicationId()));
 
     }
 
@@ -145,7 +145,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler
             BranchSession branchSession = globalSession.getBranch(branchId);
 
             BranchCommitResponse response = (BranchCommitResponse)messageSender.sendSynRequest(resourceId,
-                branchSession.getClientId(), globalSession.getApplicationId(), request);
+                branchSession.getClientId(), branchSession.getApplicationId(), request);
             return response.getBranchStatus();
         } catch (IOException e) {
             throw new TransactionException(FailedToSendBranchCommitRequest, branchId + "/" + xid, e);
@@ -169,7 +169,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler
             BranchSession branchSession = globalSession.getBranch(branchId);
 
             BranchRollbackResponse response = (BranchRollbackResponse)messageSender.sendSynRequest(resourceId,
-                branchSession.getClientId(), globalSession.getApplicationId(), request);
+                branchSession.getClientId(), branchSession.getApplicationId(), request);
             return response.getBranchStatus();
         } catch (IOException e) {
             throw new TransactionException(FailedToSendBranchRollbackRequest, branchId + "/" + xid, e);

--- a/server/src/main/java/com/alibaba/fescar/server/coordinator/DefaultCore.java
+++ b/server/src/main/java/com/alibaba/fescar/server/coordinator/DefaultCore.java
@@ -49,13 +49,13 @@ public class DefaultCore implements Core {
     }
 
     @Override
-    public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys) throws TransactionException {
+    public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys,String branchApplicationId) throws TransactionException {
         GlobalSession globalSession = assertGlobalSession(XID.getTransactionId(xid), GlobalStatus.Begin);
 
         BranchSession branchSession = new BranchSession();
         branchSession.setTransactionId(XID.getTransactionId(xid));
         branchSession.setBranchId(UUIDGenerator.generateUUID());
-        branchSession.setApplicationId(globalSession.getApplicationId());
+        branchSession.setApplicationId(branchApplicationId);
         branchSession.setTxServiceGroup(globalSession.getTransactionServiceGroup());
         branchSession.setBranchType(branchType);
         branchSession.setResourceId(resourceId);

--- a/test/src/main/java/com/alibaba/fescar/test/DataSourceBasicTest.java
+++ b/test/src/main/java/com/alibaba/fescar/test/DataSourceBasicTest.java
@@ -40,7 +40,7 @@ public class DataSourceBasicTest {
         DataSourceManager.set(new DataSourceManager() {
 
             @Override
-            public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys) throws TransactionException {
+            public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String lockKeys,String branchApplicationId) throws TransactionException {
                 return 123456L;
             }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
fix the bug of com.alibaba.fescar.core.protocol.transaction.BranchRollbackResponse@27f6c583 encode error java.lang.NullPointerException: null

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix #110

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Every branch should registe branch application id to branchSession,so should be finding netty channel through it in global comit/rollback phase,not global application id.

### Ⅴ. Special notes for reviews

