### PR TITLE
fix #150 use ServerBootstrap#childOption() to set SO_KEEPALIVE

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingServer.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingServer.java
@@ -112,7 +112,7 @@ public abstract class AbstractRpcRemotingServer extends AbstractRpcRemoting impl
             .channel(nettyServerConfig.SERVER_CHANNEL_CLAZZ)
             .option(ChannelOption.SO_BACKLOG, nettyServerConfig.getSoBackLogSize())
             .option(ChannelOption.SO_REUSEADDR, true)
-            .option(ChannelOption.SO_KEEPALIVE, true)
+            .childOption(ChannelOption.SO_KEEPALIVE, true)
             .childOption(ChannelOption.TCP_NODELAY, true)
             .childOption(ChannelOption.SO_SNDBUF, nettyServerConfig.getServerSocketSendBufSize())
             .childOption(ChannelOption.SO_RCVBUF, nettyServerConfig.getServerSocketResvBufSize())

--- a/server/src/main/java/com/alibaba/fescar/server/store/FileTransactionStoreManager.java
+++ b/server/src/main/java/com/alibaba/fescar/server/store/FileTransactionStoreManager.java
@@ -177,7 +177,7 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
 
         } catch (IOException exx) {
         } finally {
-            closeFile(raf, null);
+            closeFile(raf);
         }
         return false;
     }
@@ -228,7 +228,7 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
                         recoverCurrOffset = fileChannel.position();
                     }
                 }
-                closeFile(raf, fileChannel);
+                closeFile(raf);
             } catch (IOException exx) {
                 LOGGER.error("file close error," + exx.getMessage());
             }
@@ -241,12 +241,8 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
         return file.getName().endsWith(HIS_DATA_FILENAME_POSTFIX);
     }
 
-    private void closeFile(RandomAccessFile raf, FileChannel fileChannel) {
+    private void closeFile(RandomAccessFile raf) {
         try {
-            if (null != fileChannel) {
-                fileChannel.close();
-                fileChannel = null;
-            }
             if (null != raf) {
                 raf.close();
                 raf = null;
@@ -353,7 +349,7 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
                     }
                 }
                 currFileChannel.force(true);
-                closeFile(currRaf, currFileChannel);
+                closeFile(currRaf);
                 Files.move(currDataFile.toPath(), new File(hisFullFileName).toPath(),
                     StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException exx) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Netty `SO_KEEPALIVE` option not works on `ServerBootstrap#option()`, should replace with `ServerBootstrap#childOption()`

### Ⅱ. Does this pull request fix one issue?
fix #150 


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

