### PR TITLE
添加插件处理机制,目前主要解决对hint的支持,包括业务sql执行阶段和undolog处理阶段

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,5 +198,14 @@
                 <version>1.5.0.Final</version>
             </extension>
         </extensions>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/ConnectionProxy.java
@@ -18,6 +18,7 @@ package com.alibaba.fescar.rm.datasource;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.List;
 
 import com.alibaba.fescar.core.exception.TransactionException;
 import com.alibaba.fescar.core.exception.TransactionExceptionCode;
@@ -51,9 +52,8 @@ public class ConnectionProxy extends AbstractConnectionProxy {
         context.bind(xid);
     }
 
-    public void checkLock(TableRecords records) throws SQLException {
+    public void checkLock(String lockKeys) throws SQLException {
         // Just check lock without requiring lock by now.
-        String lockKeys = buildLockKey(records);
         try {
             boolean lockable = DataSourceManager.get().lockQuery(BranchType.AT, getDataSourceProxy().getResourceId(), context.getXid(), lockKeys);
             if (!lockable) {
@@ -63,9 +63,9 @@ public class ConnectionProxy extends AbstractConnectionProxy {
             recognizeLockKeyConflictException(e);
         }
     }
-    public void register(TableRecords records) throws SQLException {
+
+    public void register(String lockKeys) throws SQLException {
         // Just check lock without requiring lock by now.
-        String lockKeys = buildLockKey(records);
         try {
             DataSourceManager.get().branchRegister(BranchType.AT, getDataSourceProxy().getResourceId(), null, context.getXid(), lockKeys);
         } catch (TransactionException e) {
@@ -82,44 +82,12 @@ public class ConnectionProxy extends AbstractConnectionProxy {
 
     }
 
-    public void prepareUndoLog(SQLType sqlType, String tableName, TableRecords beforeImage, TableRecords afterImage) throws SQLException {
-        TableRecords lockKeyRecords = afterImage;
-        if (sqlType == SQLType.DELETE) {
-            lockKeyRecords = beforeImage;
-        }
-        String lockKeys = buildLockKey(lockKeyRecords);
-        context.appendLockKey(lockKeys);
-        SQLUndoLog sqlUndoLog = buildUndoItem(sqlType, tableName, beforeImage, afterImage);
+    public void appendLockKey(String lockKey) {
+        context.appendLockKey(lockKey);
+    }
+
+    public void appendUndoItem(SQLUndoLog sqlUndoLog) {
         context.appendUndoItem(sqlUndoLog);
-    }
-
-    private SQLUndoLog buildUndoItem(SQLType sqlType, String tableName, TableRecords beforeImage, TableRecords afterImage) {
-        SQLUndoLog sqlUndoLog = new SQLUndoLog();
-        sqlUndoLog.setSqlType(sqlType);
-        sqlUndoLog.setTableName(tableName);
-        sqlUndoLog.setBeforeImage(beforeImage);
-        sqlUndoLog.setAfterImage(afterImage);
-        return sqlUndoLog;
-    }
-
-    private String buildLockKey(TableRecords rowsIncludingPK) {
-        if (rowsIncludingPK.size() == 0) {
-            return null;
-        }
-        StringBuilder sb = new StringBuilder();
-        sb.append(rowsIncludingPK.getTableMeta().getTableName());
-        sb.append(":");
-
-        boolean flag = false;
-        for (Field field : rowsIncludingPK.pkRows()) {
-            if (flag) {
-                sb.append(",");
-            } else {
-                flag = true;
-            }
-            sb.append(field.getValue());
-        }
-        return sb.toString();
     }
 
     @Override
@@ -165,8 +133,9 @@ public class ConnectionProxy extends AbstractConnectionProxy {
         if (context.inGlobalTransaction()) {
             if (context.isBranchRegistered()) {
                 report(false);
-            }}
-            context.reset();
+            }
+        }
+        context.reset();
     }
 
     @Override

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceProxy.java
@@ -18,9 +18,13 @@ package com.alibaba.fescar.rm.datasource;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.*;
 
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.fescar.core.model.Resource;
+import com.alibaba.fescar.rm.datasource.plugin.Plugin;
+import com.alibaba.fescar.rm.datasource.plugin.PluginContext;
+import com.alibaba.fescar.rm.datasource.plugin.PluginManager;
 
 public class DataSourceProxy extends AbstractDataSourceProxy implements Resource {
 
@@ -28,9 +32,16 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
 
     private boolean managed = false;
 
+    private PluginManager pluginManager = new PluginManager();
+
+    public PluginManager getPluginManager() {
+        return pluginManager;
+    }
+
     public DataSourceProxy(DruidDataSource targetDataSource) {
         super(targetDataSource);
     }
+
     public DataSourceProxy(DruidDataSource targetDataSource, String resourceGroupId) {
         super(targetDataSource);
         this.resourceGroupId = resourceGroupId;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/DataSourceProxy.java
@@ -32,7 +32,7 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
 
     private boolean managed = false;
 
-    private PluginManager pluginManager = new PluginManager();
+    private PluginManager pluginManager;
 
     public PluginManager getPluginManager() {
         return pluginManager;
@@ -40,11 +40,13 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
 
     public DataSourceProxy(DruidDataSource targetDataSource) {
         super(targetDataSource);
+        pluginManager = new PluginManager(this);
     }
 
     public DataSourceProxy(DruidDataSource targetDataSource, String resourceGroupId) {
         super(targetDataSource);
         this.resourceGroupId = resourceGroupId;
+        pluginManager = new PluginManager(this);
     }
 
     private void assertManaged() {

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/AbstractDMLBaseExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/AbstractDMLBaseExecutor.java
@@ -18,11 +18,17 @@ package com.alibaba.fescar.rm.datasource.exec;
 
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
 
 import com.alibaba.fescar.rm.datasource.AbstractConnectionProxy;
+import com.alibaba.fescar.rm.datasource.ConnectionContext;
+import com.alibaba.fescar.rm.datasource.ConnectionProxy;
 import com.alibaba.fescar.rm.datasource.StatementProxy;
 import com.alibaba.fescar.rm.datasource.sql.SQLRecognizer;
+import com.alibaba.fescar.rm.datasource.sql.SQLType;
+import com.alibaba.fescar.rm.datasource.sql.struct.Field;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
+import com.alibaba.fescar.rm.datasource.undo.SQLUndoLog;
 
 public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends BaseTransactionalExecutor<T, S> {
 
@@ -44,7 +50,7 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
         TableRecords beforeImage = beforeImage();
         T result = statementCallback.execute(statementProxy.getTargetStatement(), args);
         TableRecords afterImage = afterImage(beforeImage);
-        statementProxy.getConnectionProxy().prepareUndoLog(sqlRecognizer.getSQLType(), sqlRecognizer.getTableName(), beforeImage, afterImage);
+        prepareUndoLog(beforeImage, afterImage);
         return result;
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/BaseTransactionalExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/BaseTransactionalExecutor.java
@@ -21,11 +21,19 @@ import java.sql.Statement;
 import java.util.List;
 
 import com.alibaba.fescar.core.context.RootContext;
+import com.alibaba.fescar.rm.datasource.ConnectionProxy;
 import com.alibaba.fescar.rm.datasource.StatementProxy;
+import com.alibaba.fescar.rm.datasource.plugin.Plugin;
+import com.alibaba.fescar.rm.datasource.plugin.PluginContext;
+import com.alibaba.fescar.rm.datasource.plugin.PluginManager;
+import com.alibaba.fescar.rm.datasource.plugin.context.LockKeyBuildAfterContext;
 import com.alibaba.fescar.rm.datasource.sql.SQLRecognizer;
+import com.alibaba.fescar.rm.datasource.sql.SQLType;
 import com.alibaba.fescar.rm.datasource.sql.struct.Field;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableMeta;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableMetaCache;
+import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
+import com.alibaba.fescar.rm.datasource.undo.SQLUndoLog;
 
 public abstract class BaseTransactionalExecutor<T, S extends Statement> implements Executor {
 
@@ -75,5 +83,66 @@ public abstract class BaseTransactionalExecutor<T, S extends Statement> implemen
         tableMeta = TableMetaCache.getTableMeta(statementProxy.getConnectionProxy().getDataSourceProxy(), tableName);
         return tableMeta;
     }
+
+    protected void prepareUndoLog(TableRecords beforeImage, TableRecords afterImage) {
+        ConnectionProxy connectionProxy = statementProxy.getConnectionProxy();
+        SQLType sqlType = sqlRecognizer.getSQLType();
+
+        TableRecords lockKeyRecords = afterImage;
+        if (sqlType == SQLType.DELETE) {
+            lockKeyRecords = beforeImage;
+        }
+        String lockKeys = buildLockKey(lockKeyRecords);
+        connectionProxy.appendLockKey(lockKeys);
+
+        SQLUndoLog sqlUndoLog = new SQLUndoLog();
+        sqlUndoLog.setSqlType(sqlType);
+        sqlUndoLog.setSqlHints(sqlRecognizer.getSqlHints());
+        sqlUndoLog.setTableName(sqlRecognizer.getTableName());
+        sqlUndoLog.setBeforeImage(beforeImage);
+        sqlUndoLog.setAfterImage(afterImage);
+        connectionProxy.appendUndoItem(sqlUndoLog);
+    }
+
+    /**
+     * ${tableName}:${pkV1},${pkV2},...
+     *
+     * @param rowsIncludingPK
+     * @return
+     */
+    protected String buildLockKey(TableRecords rowsIncludingPK) {
+        if (rowsIncludingPK.size() == 0) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(rowsIncludingPK.getTableMeta().getTableName());
+        sb.append(":");
+
+        boolean flag = false;
+        for (Field field : rowsIncludingPK.pkRows()) {
+            if (flag) {
+                sb.append(",");
+            } else {
+                flag = true;
+            }
+            sb.append(field.getValue());
+        }
+        PluginManager pluginManager = getPluginManager();
+        String lockKeys = pluginManager.execLockKeyBuildAfter(sqlRecognizer.getSqlHints(), rowsIncludingPK, sb.toString());
+        return lockKeys;
+    }
+
+    protected PluginManager getPluginManager() {
+        ConnectionProxy connectionProxy = statementProxy.getConnectionProxy();
+        PluginManager pluginManager = connectionProxy.getDataSourceProxy().getPluginManager();
+        return pluginManager;
+    }
+
+    protected String prepareSql(String originSql) {
+        List<String> hints = sqlRecognizer.getSqlHints();
+        String sql = getPluginManager().execSqlBuildAfter(hints, originSql);
+        return sql;
+    }
+
 
 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/BaseTransactionalExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/BaseTransactionalExecutor.java
@@ -73,14 +73,12 @@ public abstract class BaseTransactionalExecutor<T, S extends Statement> implemen
     }
 
     protected TableMeta getTableMeta() {
-        return getTableMeta(sqlRecognizer.getTableName());
-    }
-
-    protected TableMeta getTableMeta(String tableName) {
         if (tableMeta != null) {
             return tableMeta;
         }
-        tableMeta = TableMetaCache.getTableMeta(statementProxy.getConnectionProxy().getDataSourceProxy(), tableName);
+        String tableName = sqlRecognizer.getTableName();
+        List<String> sqlHints = sqlRecognizer.getSqlHints();
+        tableMeta = TableMetaCache.getTableMeta(sqlHints, tableName, statementProxy.getConnectionProxy().getDataSourceProxy());
         return tableMeta;
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/DeleteExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/DeleteExecutor.java
@@ -39,7 +39,7 @@ public class DeleteExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
     @Override
     protected TableRecords beforeImage() throws SQLException {
         SQLDeleteRecognizer visitor = (SQLDeleteRecognizer) sqlRecognizer;
-        TableMeta tmeta = getTableMeta(visitor.getTableName());
+        TableMeta tmeta = getTableMeta();
         List<String> columns = new ArrayList<>();
         for (String column : tmeta.getAllColumns().keySet()) {
             columns.add(column);

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/DeleteExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/DeleteExecutor.java
@@ -63,6 +63,8 @@ public class DeleteExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
         selectSQLAppender.append(" FROM " + tmeta.getTableName() + " WHERE " + whereCondition + " FOR UPDATE");
         String selectSQL = selectSQLAppender.toString();
 
+        selectSQL = prepareSql(selectSQL);
+
         TableRecords beforeImage = null;
         PreparedStatement ps = null;
         Statement st = null;
@@ -73,7 +75,7 @@ public class DeleteExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
                 rs = st.executeQuery(selectSQL);
             } else {
                 ps = statementProxy.getConnection().prepareStatement(selectSQL);
-                for (int i = 0; i< paramAppender.size(); i++) {
+                for (int i = 0; i < paramAppender.size(); i++) {
                     ps.setObject(i + 1, paramAppender.get(i));
                 }
                 rs = ps.executeQuery();

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
@@ -93,7 +93,8 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
                 // specify Statement.RETURN_GENERATED_KEYS to
                 // Statement.executeUpdate() or Connection.prepareStatement().
                 if ("S1009".equalsIgnoreCase(e.getSQLState())) {
-                    genKeys = statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
+                    String sql = prepareSql("SELECT LAST_INSERT_ID()");
+                    genKeys = statementProxy.getTargetStatement().executeQuery(sql);
                 } else {
                     throw e;
                 }
@@ -127,8 +128,10 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
         }
         PreparedStatement ps = null;
         ResultSet rs = null;
+
         try {
-            ps = statementProxy.getConnection().prepareStatement(selectSQLAppender.toString());
+            String sql=prepareSql(selectSQLAppender.toString());
+            ps = statementProxy.getConnection().prepareStatement(sql);
 
             for (int i = 1; i <= pkValues.size(); i++) {
                 ps.setObject(i, pkValues.get(i - 1));

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/SelectForUpdateExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/SelectForUpdateExecutor.java
@@ -60,7 +60,7 @@ public class SelectForUpdateExecutor<S extends Statement> extends BaseTransactio
             selectSQLAppender.append(" WHERE " + whereCondition);
         }
         selectSQLAppender.append(" FOR UPDATE");
-        String selectPKSQL = selectSQLAppender.toString();
+        String selectPKSQL = prepareSql(selectSQLAppender.toString());
 
         try {
             if (originalAutoCommit) {
@@ -87,7 +87,8 @@ public class SelectForUpdateExecutor<S extends Statement> extends BaseTransactio
                     }
 
                     TableRecords selectPKRows = TableRecords.buildRecords(getTableMeta(), rsPK);
-                    statementProxy.getConnectionProxy().checkLock(selectPKRows);
+                    String lockKey = buildLockKey(selectPKRows);
+                    statementProxy.getConnectionProxy().checkLock(lockKey);
                     break;
 
                 } catch (LockConflictException lce) {

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/UpdateExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/UpdateExecutor.java
@@ -62,7 +62,7 @@ public class UpdateExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
             whereCondition = visitor.getWhereCondition();
         }
         selectSQLAppender.append(" FROM " + tmeta.getTableName() + " WHERE " + whereCondition + " FOR UPDATE");
-        String selectSQL = selectSQLAppender.toString();
+        String selectSQL = prepareSql(selectSQLAppender.toString());
 
         TableRecords beforeImage = null;
         PreparedStatement ps = null;
@@ -74,7 +74,7 @@ public class UpdateExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
                 rs = st.executeQuery(selectSQL);
             } else {
                 ps = statementProxy.getConnection().prepareStatement(selectSQL);
-                for (int i = 0; i< paramAppender.size(); i++) {
+                for (int i = 0; i < paramAppender.size(); i++) {
                     ps.setObject(i + 1, paramAppender.get(i));
                 }
                 rs = ps.executeQuery();
@@ -117,7 +117,7 @@ public class UpdateExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
         }
         List<Field> pkRows = beforeImage.pkRows();
         selectSQLAppender.append(" FROM " + tmeta.getTableName() + " WHERE " + buildWhereConditionByPKs(pkRows) + " FOR UPDATE");
-        String selectSQL = selectSQLAppender.toString();
+        String selectSQL = prepareSql(selectSQLAppender.toString());
 
         TableRecords afterImage = null;
         PreparedStatement pst = null;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/Plugin.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/Plugin.java
@@ -1,0 +1,21 @@
+package com.alibaba.fescar.rm.datasource.plugin;
+
+import java.util.List;
+
+public interface Plugin {
+
+    /**
+     * 当前插件支持的action列表
+     *
+     * @return
+     */
+    List<String> supportedActions();
+
+    /**
+     * 执行业务处理,并返回结果对象
+     *
+     * @param context
+     * @return
+     */
+    Object proc(PluginContext context);
+}

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginConstants.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginConstants.java
@@ -6,4 +6,6 @@ public class PluginConstants {
 
     public static final String ACTION_LOCK_KEY_BUILD_AFTER = "lockKeyBuildAfter";
 
+    public static final String ACTION_TABLE_META_BEFORE = "tableMetaBeforeContext";
+
 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginConstants.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginConstants.java
@@ -1,0 +1,9 @@
+package com.alibaba.fescar.rm.datasource.plugin;
+
+public class PluginConstants {
+
+    public static final String ACTION_SQL_BUILD_AFTER = "sqlBuildAfter";
+
+    public static final String ACTION_LOCK_KEY_BUILD_AFTER = "lockKeyBuildAfter";
+
+}

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginContext.java
@@ -1,0 +1,43 @@
+package com.alibaba.fescar.rm.datasource.plugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PluginContext {
+    /**
+     * 业务类型
+     */
+    private String action;
+    /**
+     * 业务处理相关参数
+     */
+    protected Map<String, Object> args = new HashMap<>();
+    /**
+     * proc执行前已经产生的业务结果对象
+     */
+    private Object result;
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public Map<String, Object> getArgs() {
+        return args;
+    }
+
+    public void setArgs(Map<String, Object> args) {
+        this.args = args;
+    }
+
+    public Object getResult() {
+        return result;
+    }
+
+    public void setResult(Object result) {
+        this.result = result;
+    }
+}

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
@@ -1,0 +1,93 @@
+package com.alibaba.fescar.rm.datasource.plugin;
+
+import com.alibaba.fescar.rm.datasource.plugin.context.LockKeyBuildAfterContext;
+import com.alibaba.fescar.rm.datasource.plugin.context.SqlBuildAfterContext;
+import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
+
+import java.util.*;
+
+/**
+ * 插件管理类
+ */
+public class PluginManager {
+    /**
+     * plugins
+     */
+    private Map<String, List<Plugin>> pluginMap = new HashMap<>();
+
+    public Map<String, List<Plugin>> getPluginMap() {
+        return pluginMap;
+    }
+
+    /**
+     * 添加插件
+     *
+     * @param plugin 插件实例对象
+     */
+    public void addPlugins(Plugin plugin) {
+        for (String action : plugin.supportedActions()) {
+            List<Plugin> plugins = pluginMap.get(action);
+            if (plugins == null) {
+                plugins = new ArrayList<>();
+                pluginMap.put(action, plugins);
+            }
+            plugins.add(plugin);
+        }
+    }
+
+    /**
+     * 获取特定action相关的插件列表
+     *
+     * @param action 插件相关的action
+     * @return
+     */
+    public List<Plugin> getPlugins(String action) {
+        return pluginMap.getOrDefault(action, Collections.emptyList());
+    }
+
+
+    /**
+     * sql语句构建后处理
+     *
+     * @param sqlHints  SqlHint列表
+     * @param originSql 已经构建的sql
+     * @return
+     */
+    public String execSqlBuildAfter(List<String> sqlHints, String originSql) {
+        SqlBuildAfterContext context = new SqlBuildAfterContext(sqlHints, originSql);
+        Object result = execPlugin(context, PluginConstants.ACTION_SQL_BUILD_AFTER);
+        return (String) result;
+    }
+
+    /**
+     * lockKey构建后处理
+     *
+     * @param sqlHints     SqlHint列表
+     * @param tableRecords TableRecords对象实例
+     * @param lockKey      已经构建的lockKey
+     * @return
+     */
+    public String execLockKeyBuildAfter(List<String> sqlHints, TableRecords tableRecords, String lockKey) {
+        LockKeyBuildAfterContext context = new LockKeyBuildAfterContext(sqlHints, tableRecords, lockKey);
+        Object result = execPlugin(context, PluginConstants.ACTION_LOCK_KEY_BUILD_AFTER);
+        return (String) result;
+    }
+
+    /**
+     * 执行特定action相关的处理
+     *
+     * @param context plugin上下文对象
+     * @param action  插件相关的action
+     * @return
+     */
+    public Object execPlugin(PluginContext context, String action) {
+        List<Plugin> pluginList = getPlugins(action);
+        for (Plugin plugin : pluginList) {
+            Object result = plugin.proc(context);
+            //本次执行结果传递到后续处理
+            context.setResult(result);
+        }
+        return context.getResult();
+    }
+
+}

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
@@ -44,7 +44,7 @@ public class PluginManager {
     public List<Plugin> getPlugins(String action) {
         List<Plugin> plugins = pluginMap.get(action);
         if (plugins == null) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
         return plugins;
     }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
@@ -42,7 +42,11 @@ public class PluginManager {
      * @return
      */
     public List<Plugin> getPlugins(String action) {
-        return pluginMap.getOrDefault(action, Collections.emptyList());
+        List<Plugin> plugins = pluginMap.get(action);
+        if (plugins == null) {
+            return Collections.emptyList();
+        }
+        return plugins;
     }
 
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/PluginManager.java
@@ -1,7 +1,10 @@
 package com.alibaba.fescar.rm.datasource.plugin;
 
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fescar.rm.datasource.DataSourceProxy;
 import com.alibaba.fescar.rm.datasource.plugin.context.LockKeyBuildAfterContext;
 import com.alibaba.fescar.rm.datasource.plugin.context.SqlBuildAfterContext;
+import com.alibaba.fescar.rm.datasource.plugin.context.TableMetaBeforeContext;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
 
 import java.util.*;
@@ -10,6 +13,28 @@ import java.util.*;
  * 插件管理类
  */
 public class PluginManager {
+
+    public PluginManager() {
+
+    }
+
+    public PluginManager(DataSourceProxy dataSourceProxy) {
+        this.setDataSourceProxy(dataSourceProxy);
+    }
+
+    /**
+     * dataSourceProxy
+     */
+    private DataSourceProxy dataSourceProxy;
+
+    public DataSourceProxy getDataSourceProxy() {
+        return dataSourceProxy;
+    }
+
+    public void setDataSourceProxy(DataSourceProxy dataSourceProxy) {
+        this.dataSourceProxy = dataSourceProxy;
+    }
+
     /**
      * plugins
      */
@@ -75,6 +100,21 @@ public class PluginManager {
         LockKeyBuildAfterContext context = new LockKeyBuildAfterContext(sqlHints, tableRecords, lockKey);
         Object result = execPlugin(context, PluginConstants.ACTION_LOCK_KEY_BUILD_AFTER);
         return (String) result;
+    }
+
+    /**
+     * table Meta构建前处理
+     *
+     * @param sqlHints            SqlHint列表
+     * @param tableName           目标表名
+     * @param defaultCacheKey     默认cacheKey
+     * @param defaultMetaQuerySql 默认metaQuerySql
+     * @return
+     */
+    public TableMetaBeforeContext execTableMetaBefore(List<String> sqlHints, String tableName, String defaultCacheKey, String defaultMetaQuerySql) {
+        TableMetaBeforeContext context = new TableMetaBeforeContext(sqlHints, tableName, defaultCacheKey, defaultMetaQuerySql);
+        execPlugin(context, PluginConstants.ACTION_TABLE_META_BEFORE);
+        return context;
     }
 
     /**

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
@@ -30,7 +30,10 @@ public class LockKeyBuildAfterContext extends PluginContext {
     }
 
     public List<String> getSqlHints() {
-        List<String> sqlHints = (List<String>) this.args.getOrDefault(ARG_KEY_SQL_HINTS, Collections.emptyList());
+        List<String> sqlHints = (List<String>) this.args.get(ARG_KEY_SQL_HINTS);
+        if (sqlHints == null) {
+            return Collections.emptyList();
+        }
         return sqlHints;
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
@@ -50,5 +50,8 @@ public class LockKeyBuildAfterContext extends PluginContext {
         this.args.put(ARG_KEY_TABLE_RECORDS, tableRecords);
     }
 
+    public String getResultLockKey() {
+        return (String) getResult();
+    }
 
 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
@@ -1,0 +1,51 @@
+package com.alibaba.fescar.rm.datasource.plugin.context;
+
+import com.alibaba.fescar.rm.datasource.plugin.PluginConstants;
+import com.alibaba.fescar.rm.datasource.plugin.PluginContext;
+import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public class LockKeyBuildAfterContext extends PluginContext {
+
+    private static final String ARG_KEY_TABLE_RECORDS = "tableRecords";
+    private static final String ARG_KEY_SQL_HINTS = "sqlHints";
+
+    public LockKeyBuildAfterContext(List<String> sqlHints, TableRecords tableRecords, String lockKey) {
+        this.setSqlHints(sqlHints);
+        this.setTableRecords(tableRecords);
+        this.setResult(lockKey);
+    }
+
+    @Override
+    public String getAction() {
+        return PluginConstants.ACTION_LOCK_KEY_BUILD_AFTER;
+    }
+
+    @Override
+    public void setAction(String action) {
+
+    }
+
+    public List<String> getSqlHints() {
+        List<String> sqlHints = (List<String>) this.args.getOrDefault(ARG_KEY_SQL_HINTS, Collections.emptyList());
+        return sqlHints;
+    }
+
+    public void setSqlHints(List<String> sqlHints) {
+        this.args.put(ARG_KEY_SQL_HINTS, sqlHints);
+    }
+
+    public TableRecords getTableRecords() {
+        TableRecords tableRecords = (TableRecords) this.args.get(ARG_KEY_TABLE_RECORDS);
+        return tableRecords;
+    }
+
+    public void setTableRecords(TableRecords tableRecords) {
+        this.args.put(ARG_KEY_TABLE_RECORDS, tableRecords);
+    }
+
+
+}

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/LockKeyBuildAfterContext.java
@@ -4,7 +4,7 @@ import com.alibaba.fescar.rm.datasource.plugin.PluginConstants;
 import com.alibaba.fescar.rm.datasource.plugin.PluginContext;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -32,7 +32,7 @@ public class LockKeyBuildAfterContext extends PluginContext {
     public List<String> getSqlHints() {
         List<String> sqlHints = (List<String>) this.args.get(ARG_KEY_SQL_HINTS);
         if (sqlHints == null) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
         return sqlHints;
     }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
@@ -1,0 +1,39 @@
+package com.alibaba.fescar.rm.datasource.plugin.context;
+
+import com.alibaba.fescar.rm.datasource.plugin.PluginConstants;
+import com.alibaba.fescar.rm.datasource.plugin.PluginContext;
+import com.alibaba.fescar.rm.datasource.undo.SQLUndoLog;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public class SqlBuildAfterContext extends PluginContext {
+
+    private static final String ARG_KEY_SQL_HINTS = "sqlHints";
+
+    public SqlBuildAfterContext(List<String> sqlHints, String originSql) {
+        this.setSqlHints(sqlHints);
+        this.setResult(originSql);
+    }
+
+    @Override
+    public String getAction() {
+        return PluginConstants.ACTION_SQL_BUILD_AFTER;
+    }
+
+    @Override
+    public void setAction(String action) {
+
+    }
+
+    public List<String> getSqlHints() {
+        return (List<String>) this.args.getOrDefault(ARG_KEY_SQL_HINTS, Collections.emptyList());
+    }
+
+    public void setSqlHints(List<String> sqlHints) {
+        this.args.put(ARG_KEY_SQL_HINTS, sqlHints);
+    }
+
+
+}

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
@@ -28,7 +28,11 @@ public class SqlBuildAfterContext extends PluginContext {
     }
 
     public List<String> getSqlHints() {
-        return (List<String>) this.args.getOrDefault(ARG_KEY_SQL_HINTS, Collections.emptyList());
+        List<String> sqlHints = (List<String>) this.args.get(ARG_KEY_SQL_HINTS);
+        if (sqlHints == null) {
+            return Collections.emptyList();
+        }
+        return sqlHints;
     }
 
     public void setSqlHints(List<String> sqlHints) {

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
@@ -38,5 +38,8 @@ public class SqlBuildAfterContext extends PluginContext {
         this.args.put(ARG_KEY_SQL_HINTS, sqlHints);
     }
 
+    public String getResultSql() {
+        return (String) getResult();
+    }
 
 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/SqlBuildAfterContext.java
@@ -2,9 +2,8 @@ package com.alibaba.fescar.rm.datasource.plugin.context;
 
 import com.alibaba.fescar.rm.datasource.plugin.PluginConstants;
 import com.alibaba.fescar.rm.datasource.plugin.PluginContext;
-import com.alibaba.fescar.rm.datasource.undo.SQLUndoLog;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -30,7 +29,7 @@ public class SqlBuildAfterContext extends PluginContext {
     public List<String> getSqlHints() {
         List<String> sqlHints = (List<String>) this.args.get(ARG_KEY_SQL_HINTS);
         if (sqlHints == null) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
         return sqlHints;
     }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/TableMetaBeforeContext.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/plugin/context/TableMetaBeforeContext.java
@@ -1,0 +1,77 @@
+package com.alibaba.fescar.rm.datasource.plugin.context;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fescar.rm.datasource.plugin.PluginConstants;
+import com.alibaba.fescar.rm.datasource.plugin.PluginContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class TableMetaBeforeContext extends PluginContext {
+
+    private static final String ARG_KEY_SQL_HINTS = "sqlHints";
+    private static final String ARG_KEY_TABLE_NAME = "tableName";
+
+    public TableMetaBeforeContext(List<String> sqlHints, String tableName, String defaultCacheKey, String defaultMetaQuerySql) {
+        this.setSqlHints(sqlHints);
+        this.setTableName(tableName);
+        this.setResultData(defaultCacheKey, defaultMetaQuerySql);
+    }
+
+    @Override
+    public String getAction() {
+        return PluginConstants.ACTION_SQL_BUILD_AFTER;
+    }
+
+    @Override
+    public void setAction(String action) {
+
+    }
+
+    public List<String> getSqlHints() {
+        List<String> sqlHints = (List<String>) this.args.get(ARG_KEY_SQL_HINTS);
+        if (sqlHints == null) {
+            return new ArrayList<>();
+        }
+        return sqlHints;
+    }
+
+    public void setSqlHints(List<String> sqlHints) {
+        this.args.put(ARG_KEY_SQL_HINTS, sqlHints);
+    }
+
+    public void setTableName(String tableName) {
+        this.args.put(ARG_KEY_TABLE_NAME, tableName);
+    }
+
+    public String getTableName() {
+        return (String) this.args.get(ARG_KEY_TABLE_NAME);
+    }
+
+    @Override
+    public void setResult(Object result) {
+        if (result != null && !(result instanceof JSONObject)) {
+            throw new IllegalArgumentException("result must be JSONObject");
+        }
+        super.setResult(result);
+    }
+
+    public void setResultData(String cacheKey, String metaQuerySql) {
+        JSONObject resultObject = new JSONObject();
+        resultObject.fluentPut("cacheKey", cacheKey)
+                .fluentPut("metaQuerySql", metaQuerySql)
+        ;
+        this.setResult(resultObject);
+    }
+
+    public String getResultForCacheKey() {
+        JSONObject resultObject = (JSONObject) this.getResult();
+        return resultObject.getString("cacheKey");
+    }
+
+    public String getResultForMetaQuerySql() {
+        JSONObject resultObject = (JSONObject) this.getResult();
+        return resultObject.getString("metaQuerySql");
+    }
+}

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/SQLRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/SQLRecognizer.java
@@ -16,7 +16,15 @@
 
 package com.alibaba.fescar.rm.datasource.sql;
 
+import java.util.List;
+
 public interface SQLRecognizer {
+
+    /**
+     * Hint of SQL
+     * @return
+     */
+    List<String> getSqlHints();
 
     /**
      * Type of the SQL. INSERT/UPDATE/DELETE ...

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/BaseRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/BaseRecognizer.java
@@ -18,6 +18,8 @@ package com.alibaba.fescar.rm.datasource.sql.druid;
 
 import com.alibaba.fescar.rm.datasource.sql.SQLRecognizer;
 
+import java.util.List;
+
 public abstract class BaseRecognizer implements SQLRecognizer {
 
     public static class VMarker {
@@ -30,9 +32,22 @@ public abstract class BaseRecognizer implements SQLRecognizer {
 
     protected String originalSQL;
 
+    protected List<String> sqlHints;
+
     public BaseRecognizer(String originalSQL) {
         this.originalSQL = originalSQL;
 
+    }
+
+    public BaseRecognizer(String originalSQL,List<String> sqlHints) {
+        this.originalSQL = originalSQL;
+        this.sqlHints=sqlHints;
+    }
+
+
+    @Override
+    public List<String> getSqlHints() {
+        return sqlHints;
     }
 
     @Override

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLDeleteRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLDeleteRecognizer.java
@@ -35,10 +35,6 @@ public class MySQLDeleteRecognizer extends BaseRecognizer implements SQLDeleteRe
 
     private final MySqlDeleteStatement ast;
 
-    public MySQLDeleteRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL, ast, new ArrayList<>());
-    }
-
     public MySQLDeleteRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
         super(originalSQL, sqlHints);
         this.ast = (MySqlDeleteStatement) ast;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLDeleteRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLDeleteRecognizer.java
@@ -36,7 +36,7 @@ public class MySQLDeleteRecognizer extends BaseRecognizer implements SQLDeleteRe
     private final MySqlDeleteStatement ast;
 
     public MySQLDeleteRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL,ast, Collections.emptyList());
+        this(originalSQL, ast, new ArrayList<>());
     }
 
     public MySQLDeleteRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
@@ -53,7 +53,7 @@ public class MySQLDeleteRecognizer extends BaseRecognizer implements SQLDeleteRe
     public String getTableSource() {
         StringBuffer sb = new StringBuffer();
         MySqlOutputVisitor visitor = new MySqlOutputVisitor(sb);
-        visitor.visit((SQLExprTableSource)ast.getTableSource());
+        visitor.visit((SQLExprTableSource) ast.getTableSource());
         return sb.toString();
     }
 
@@ -68,7 +68,7 @@ public class MySQLDeleteRecognizer extends BaseRecognizer implements SQLDeleteRe
                 return false;
             }
         };
-        visitor.visit((SQLExprTableSource)ast.getTableSource());
+        visitor.visit((SQLExprTableSource) ast.getTableSource());
         return sb.toString();
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLDeleteRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLDeleteRecognizer.java
@@ -17,6 +17,8 @@
 package com.alibaba.fescar.rm.datasource.sql.druid;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -34,7 +36,11 @@ public class MySQLDeleteRecognizer extends BaseRecognizer implements SQLDeleteRe
     private final MySqlDeleteStatement ast;
 
     public MySQLDeleteRecognizer(String originalSQL, SQLStatement ast) {
-        super(originalSQL);
+        this(originalSQL,ast, Collections.emptyList());
+    }
+
+    public MySQLDeleteRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
+        super(originalSQL, sqlHints);
         this.ast = (MySqlDeleteStatement) ast;
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLInsertRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLInsertRecognizer.java
@@ -36,10 +36,6 @@ public class MySQLInsertRecognizer extends BaseRecognizer implements SQLInsertRe
 
     private final MySqlInsertStatement ast;
 
-    public MySQLInsertRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL, ast, new ArrayList<>());
-    }
-
     public MySQLInsertRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
         super(originalSQL, sqlHints);
         this.ast = (MySqlInsertStatement) ast;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLInsertRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLInsertRecognizer.java
@@ -17,6 +17,7 @@
 package com.alibaba.fescar.rm.datasource.sql.druid;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
@@ -36,7 +37,11 @@ public class MySQLInsertRecognizer extends BaseRecognizer implements SQLInsertRe
     private final MySqlInsertStatement ast;
 
     public MySQLInsertRecognizer(String originalSQL, SQLStatement ast) {
-        super(originalSQL);
+        this(originalSQL,ast, Collections.emptyList());
+    }
+
+    public MySQLInsertRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
+        super(originalSQL, sqlHints);
         this.ast = (MySqlInsertStatement) ast;
     }
 
@@ -96,7 +101,7 @@ public class MySQLInsertRecognizer extends BaseRecognizer implements SQLInsertRe
             rows.add(row);
             for (SQLExpr expr : valuesClause.getValues()) {
                 if (expr instanceof SQLValuableExpr) {
-                    row.add(((SQLValuableExpr)expr).getValue());
+                    row.add(((SQLValuableExpr) expr).getValue());
                 } else {
                     throw new SQLParsingException("Unknown SQLExpr: " + expr.getClass() + " " + expr);
                 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLInsertRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLInsertRecognizer.java
@@ -37,7 +37,7 @@ public class MySQLInsertRecognizer extends BaseRecognizer implements SQLInsertRe
     private final MySqlInsertStatement ast;
 
     public MySQLInsertRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL,ast, Collections.emptyList());
+        this(originalSQL, ast, new ArrayList<>());
     }
 
     public MySQLInsertRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLSelectForUpdateRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLSelectForUpdateRecognizer.java
@@ -40,7 +40,7 @@ public class MySQLSelectForUpdateRecognizer extends BaseRecognizer implements SQ
     private final SQLSelectStatement ast;
 
     public MySQLSelectForUpdateRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL,ast, Collections.emptyList());
+        this(originalSQL, ast, new ArrayList<>());
     }
 
     public MySQLSelectForUpdateRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
@@ -107,7 +107,7 @@ public class MySQLSelectForUpdateRecognizer extends BaseRecognizer implements SQ
         SQLTableSource tableSource = selectQueryBlock.getFrom();
         StringBuffer sb = new StringBuffer();
         MySqlOutputVisitor visitor = new MySqlOutputVisitor(sb);
-        visitor.visit((SQLExprTableSource)tableSource);
+        visitor.visit((SQLExprTableSource) tableSource);
         return sb.toString();
     }
 
@@ -124,7 +124,7 @@ public class MySQLSelectForUpdateRecognizer extends BaseRecognizer implements SQ
                 return false;
             }
         };
-        visitor.visit((SQLExprTableSource)tableSource);
+        visitor.visit((SQLExprTableSource) tableSource);
         return sb.toString();
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLSelectForUpdateRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLSelectForUpdateRecognizer.java
@@ -39,10 +39,6 @@ public class MySQLSelectForUpdateRecognizer extends BaseRecognizer implements SQ
 
     private final SQLSelectStatement ast;
 
-    public MySQLSelectForUpdateRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL, ast, new ArrayList<>());
-    }
-
     public MySQLSelectForUpdateRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
         super(originalSQL, sqlHints);
         this.ast = (SQLSelectStatement) ast;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLSelectForUpdateRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLSelectForUpdateRecognizer.java
@@ -17,6 +17,8 @@
 package com.alibaba.fescar.rm.datasource.sql.druid;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -38,7 +40,11 @@ public class MySQLSelectForUpdateRecognizer extends BaseRecognizer implements SQ
     private final SQLSelectStatement ast;
 
     public MySQLSelectForUpdateRecognizer(String originalSQL, SQLStatement ast) {
-        super(originalSQL);
+        this(originalSQL,ast, Collections.emptyList());
+    }
+
+    public MySQLSelectForUpdateRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
+        super(originalSQL, sqlHints);
         this.ast = (SQLSelectStatement) ast;
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLUpdateRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLUpdateRecognizer.java
@@ -40,10 +40,6 @@ public class MySQLUpdateRecognizer extends BaseRecognizer implements SQLUpdateRe
 
     private MySqlUpdateStatement ast;
 
-    public MySQLUpdateRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL, ast, new ArrayList<>());
-    }
-
     public MySQLUpdateRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
         super(originalSQL, sqlHints);
         this.ast = (MySqlUpdateStatement) ast;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLUpdateRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLUpdateRecognizer.java
@@ -41,7 +41,7 @@ public class MySQLUpdateRecognizer extends BaseRecognizer implements SQLUpdateRe
     private MySqlUpdateStatement ast;
 
     public MySQLUpdateRecognizer(String originalSQL, SQLStatement ast) {
-        this(originalSQL,ast, Collections.emptyList());
+        this(originalSQL, ast, new ArrayList<>());
     }
 
     public MySQLUpdateRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
@@ -62,11 +62,11 @@ public class MySQLUpdateRecognizer extends BaseRecognizer implements SQLUpdateRe
             SQLExpr expr = updateSetItem.getColumn();
             if (expr instanceof SQLIdentifierExpr) {
                 list.add(((SQLIdentifierExpr) expr).getName());
-            } else if (expr instanceof SQLPropertyExpr){
+            } else if (expr instanceof SQLPropertyExpr) {
                 // This is alias case, like UPDATE xxx_tbl a SET a.name = ? WHERE a.id = ?
                 SQLExpr owner = ((SQLPropertyExpr) expr).getOwner();
                 if (owner instanceof SQLIdentifierExpr) {
-                    list.add((((SQLIdentifierExpr)owner).getName() + "." + ((SQLPropertyExpr) expr).getName()));
+                    list.add((((SQLIdentifierExpr) owner).getName() + "." + ((SQLPropertyExpr) expr).getName()));
                 }
             } else {
                 throw new SQLParsingException("Unknown SQLExpr: " + expr.getClass() + " " + expr);

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLUpdateRecognizer.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/druid/MySQLUpdateRecognizer.java
@@ -17,6 +17,7 @@
 package com.alibaba.fescar.rm.datasource.sql.druid;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
@@ -40,7 +41,11 @@ public class MySQLUpdateRecognizer extends BaseRecognizer implements SQLUpdateRe
     private MySqlUpdateStatement ast;
 
     public MySQLUpdateRecognizer(String originalSQL, SQLStatement ast) {
-        super(originalSQL);
+        this(originalSQL,ast, Collections.emptyList());
+    }
+
+    public MySQLUpdateRecognizer(String originalSQL, SQLStatement ast, List<String> sqlHints) {
+        super(originalSQL, sqlHints);
         this.ast = (MySqlUpdateStatement) ast;
     }
 

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/struct/TableMetaCache.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/sql/struct/TableMetaCache.java
@@ -20,239 +20,241 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.util.StringUtils;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fescar.common.exception.ShouldNeverHappenException;
 import com.alibaba.fescar.core.context.RootContext;
 import com.alibaba.fescar.rm.datasource.AbstractConnectionProxy;
 import com.alibaba.fescar.rm.datasource.DataSourceProxy;
 
+import com.alibaba.fescar.rm.datasource.plugin.context.TableMetaBeforeContext;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 public class TableMetaCache {
 
-	private static final long CACHE_SIZE = 100000;
+    private static final long CACHE_SIZE = 100000;
 
-	private static final long EXPIRE_TIME = 900 * 1000;
+    private static final long EXPIRE_TIME = 900 * 1000;
 
     private static final Cache<String, TableMeta> TABLE_META_CACHE = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE)
-			.expireAfterWrite(EXPIRE_TIME, TimeUnit.MILLISECONDS).softValues().build();
+            .expireAfterWrite(EXPIRE_TIME, TimeUnit.MILLISECONDS).softValues().build();
 
-	public static TableMeta getTableMeta(DataSourceProxy dataSourceProxy, String tableName) {
-		return getTableMeta(dataSourceProxy.getTargetDataSource(), tableName);
-	}
+    public static TableMeta getTableMeta(List<String> sqlHints, String tableName, DataSourceProxy dataSourceProxy) {
+        DruidDataSource dataSource = dataSourceProxy.getTargetDataSource();
+        String cacheKey = dataSource.getUrl() + "." + tableName;
+        String metaQuerySql = "SELECT * FROM " + tableName + " LIMIT 1";
+        TableMetaBeforeContext context = dataSourceProxy.getPluginManager().execTableMetaBefore(sqlHints, tableName, cacheKey, metaQuerySql);
+        cacheKey = context.getResultForCacheKey();
+        metaQuerySql = context.getResultForMetaQuerySql();
+        return getTableMeta(cacheKey, metaQuerySql, dataSourceProxy.getTargetDataSource());
+    }
 
-	public static TableMeta getTableMeta(final DruidDataSource druidDataSource, final String tableName) {
-		if (StringUtils.isEmpty(tableName)) {
-			throw new IllegalArgumentException("TableMeta cannot be fetched without tableName");
-		}
+    public static TableMeta getTableMeta(final String cacheKey, final String metaQuerySql, final DruidDataSource druidDataSource) {
+        if (StringUtils.isEmpty(cacheKey) || StringUtils.isEmpty(metaQuerySql)) {
+            throw new IllegalArgumentException("cacheKey,metaQuerySql required");
+        }
 
-		String dataSourceKey = druidDataSource.getUrl();
+        TableMeta tmeta = null;
+        try {
+            tmeta = TABLE_META_CACHE.get(cacheKey, new Callable<TableMeta>() {
+                @Override
+                public TableMeta call() throws Exception {
+                    return fetchSchemeInDefaultWay(druidDataSource, metaQuerySql);
+                }
+            });
+        } catch (ExecutionException e) {
+        }
 
-		TableMeta tmeta = null;
-		final String key = dataSourceKey + "." + tableName;
-		try {
-			tmeta = TABLE_META_CACHE.get(key, new Callable<TableMeta>() {
-				@Override
-				public TableMeta call() throws Exception {
-					return fetchSchema(druidDataSource, tableName);
-				}
-			});
-		} catch (ExecutionException e) {
-		}
+        if (tmeta == null) {
+            try {
+                tmeta = fetchSchemeInDefaultWay(druidDataSource, metaQuerySql);
+            } catch (SQLException e) {
+            }
+        }
 
-		if (tmeta == null) {
-			try {
-				tmeta = fetchSchema(druidDataSource, tableName);
-			} catch (SQLException e) {
-			}
-		}
+        if (tmeta == null) {
+            throw new ShouldNeverHappenException(String.format("[xid:%s]get table meta failed. key:%s, metaQuerySql:%s"
+                    , RootContext.getXID(), cacheKey, metaQuerySql));
+        }
+        return tmeta;
+    }
 
-		if (tmeta == null) {
-			throw new ShouldNeverHappenException(String.format("[xid:%s]get tablemeta failed", RootContext.getXID()));
-		}
-		return tmeta;
-	}
+    private static TableMeta fetchSchemeInDefaultWay(DruidDataSource druidDataSource, String querySql) throws SQLException {
+        Connection conn = null;
+        java.sql.Statement stmt = null;
+        java.sql.ResultSet rs = null;
+        try {
+            conn = druidDataSource.getConnection();
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery(querySql);
+            ResultSetMetaData rsmd = rs.getMetaData();
+            DatabaseMetaData dbmd = conn.getMetaData();
 
-	private static TableMeta fetchSchema(DruidDataSource druidDataSource, String tableName) throws SQLException {
-		return fetchSchemeInDefaultWay(druidDataSource, tableName);
-	}
+            return resultSetMetaToSchema(rsmd, dbmd);
+        } catch (Exception e) {
+            if (e instanceof SQLException) {
+                throw ((SQLException) e);
+            }
+            throw new SQLException("Failed to fetch schema , querySql: " + querySql, e);
 
-	private static TableMeta fetchSchemeInDefaultWay(DruidDataSource druidDataSource, String tableName) throws SQLException {
-		Connection conn = null;
-		java.sql.Statement stmt = null;
-		java.sql.ResultSet rs = null;
-		try {
-			conn = druidDataSource.getConnection();
-			stmt = conn.createStatement();
-			StringBuffer sb = new StringBuffer("SELECT * FROM " + tableName + " LIMIT 1");
-			rs = stmt.executeQuery(sb.toString());
-			ResultSetMetaData rsmd = rs.getMetaData();
-			DatabaseMetaData dbmd = conn.getMetaData();
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (stmt != null) {
+                stmt.close();
+            }
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
 
-			return resultSetMetaToSchema(rsmd, dbmd);
-		} catch (Exception e) {
-			if (e instanceof SQLException) {
-				throw ((SQLException) e);
-			}
-			throw new SQLException("Failed to fetch schema of " + tableName, e);
+    private static TableMeta resultSetMetaToSchema(java.sql.ResultSet rs2, AbstractConnectionProxy conn, String tablename) throws SQLException {
+        String tableName = tablename;
 
-		} finally {
-			if (rs != null) {
-				rs.close();
-			}
-			if (stmt != null) {
-				stmt.close();
-			}
-			if (conn != null) {
-				conn.close();
-			}
-		}
-	}
+        TableMeta tm = new TableMeta();
+        tm.setTableName(tableName);
+        while (rs2.next()) {
+            ColumnMeta col = new ColumnMeta();
+            col.setTableName(tableName);
+            col.setColumnName(rs2.getString("COLUMN_NAME").toUpperCase());
+            String datatype = rs2.getString("DATA_TYPE");
+            if (StringUtils.equalsIgnoreCase(datatype, "NUMBER")) {
+                col.setDataType(java.sql.Types.BIGINT);
+            } else if (StringUtils.equalsIgnoreCase(datatype, "VARCHAR2")) {
+                col.setDataType(java.sql.Types.VARCHAR);
+            } else if (StringUtils.equalsIgnoreCase(datatype, "CHAR")) {
+                col.setDataType(java.sql.Types.CHAR);
+            } else if (StringUtils.equalsIgnoreCase(datatype, "DATE")) {
+                col.setDataType(java.sql.Types.DATE);
+            }
 
-	private static TableMeta resultSetMetaToSchema(java.sql.ResultSet rs2, AbstractConnectionProxy conn, String tablename) throws SQLException {
-		String tableName = tablename;
+            col.setColumnSize(rs2.getInt("DATA_LENGTH"));
 
-		TableMeta tm = new TableMeta();
-		tm.setTableName(tableName);
-		while (rs2.next()) {
-			ColumnMeta col = new ColumnMeta();
-			col.setTableName(tableName);
-			col.setColumnName(rs2.getString("COLUMN_NAME").toUpperCase());
-			String datatype = rs2.getString("DATA_TYPE");
-			if (StringUtils.equalsIgnoreCase(datatype, "NUMBER")) {
-				col.setDataType(java.sql.Types.BIGINT);
-			} else if (StringUtils.equalsIgnoreCase(datatype, "VARCHAR2")) {
-				col.setDataType(java.sql.Types.VARCHAR);
-			} else if (StringUtils.equalsIgnoreCase(datatype, "CHAR")) {
-				col.setDataType(java.sql.Types.CHAR);
-			} else if (StringUtils.equalsIgnoreCase(datatype, "DATE")) {
-				col.setDataType(java.sql.Types.DATE);
-			}
+            tm.getAllColumns().put(col.getColumnName(), col);
+        }
 
-			col.setColumnSize(rs2.getInt("DATA_LENGTH"));
+        java.sql.Statement stmt = null;
+        java.sql.ResultSet rs1 = null;
+        try {
+            stmt = conn.getTargetConnection().createStatement();
+            rs1 = stmt.executeQuery(
+                    "select a.constraint_name,  a.column_name from user_cons_columns a, user_constraints b  where a.constraint_name = b.constraint_name and b.constraint_type = 'P' and a.table_name ='"
+                            + tableName + "'");
+            while (rs1.next()) {
+                String indexName = rs1.getString(1);
+                String colName = rs1.getString(2).toUpperCase();
+                ColumnMeta col = tm.getAllColumns().get(colName);
 
-			tm.getAllColumns().put(col.getColumnName(), col);
-		}
+                if (tm.getAllIndexes().containsKey(indexName)) {
+                    IndexMeta index = tm.getAllIndexes().get(indexName);
+                    index.getValues().add(col);
+                } else {
+                    IndexMeta index = new IndexMeta();
+                    index.setIndexName(indexName);
+                    index.getValues().add(col);
+                    index.setIndextype(IndexType.PRIMARY);
+                    tm.getAllIndexes().put(indexName, index);
 
-		java.sql.Statement stmt = null;
-		java.sql.ResultSet rs1 = null;
-		try {
-			stmt = conn.getTargetConnection().createStatement();
-			rs1 = stmt.executeQuery(
-					"select a.constraint_name,  a.column_name from user_cons_columns a, user_constraints b  where a.constraint_name = b.constraint_name and b.constraint_type = 'P' and a.table_name ='"
-							+ tableName + "'");
-			while (rs1.next()) {
-				String indexName = rs1.getString(1);
-				String colName = rs1.getString(2).toUpperCase();
-				ColumnMeta col = tm.getAllColumns().get(colName);
+                }
+            }
+        } finally {
+            if (rs1 != null) {
+                rs1.close();
+            }
+            if (stmt != null) {
+                stmt.close();
+            }
+        }
 
-				if (tm.getAllIndexes().containsKey(indexName)) {
-					IndexMeta index = tm.getAllIndexes().get(indexName);
-					index.getValues().add(col);
-				} else {
-					IndexMeta index = new IndexMeta();
-					index.setIndexName(indexName);
-					index.getValues().add(col);
-					index.setIndextype(IndexType.PRIMARY);
-					tm.getAllIndexes().put(indexName, index);
+        return tm;
+    }
 
-				}
-			}
-		} finally {
-			if (rs1 != null) {
-				rs1.close();
-			}
-			if (stmt != null) {
-				stmt.close();
-			}
-		}
+    private static TableMeta resultSetMetaToSchema(ResultSetMetaData rsmd, DatabaseMetaData dbmd) throws SQLException {
+        String tableName = rsmd.getTableName(1);
+        String schemaName = rsmd.getSchemaName(1);
+        String catalogName = rsmd.getCatalogName(1);
 
-		return tm;
-	}
+        TableMeta tm = new TableMeta();
+        tm.setTableName(tableName);
 
-	private static TableMeta resultSetMetaToSchema(ResultSetMetaData rsmd, DatabaseMetaData dbmd) throws SQLException {
-		String tableName = rsmd.getTableName(1);
-		String schemaName = rsmd.getSchemaName(1);
-		String catalogName = rsmd.getCatalogName(1);
+        java.sql.ResultSet rs1 = dbmd.getColumns(catalogName, schemaName, tableName, "%");
+        while (rs1.next()) {
+            ColumnMeta col = new ColumnMeta();
+            col.setTableCat(rs1.getString("TABLE_CAT"));
+            col.setTableSchemaName(rs1.getString("TABLE_SCHEM"));
+            col.setTableName(rs1.getString("TABLE_NAME"));
+            col.setColumnName(rs1.getString("COLUMN_NAME").toUpperCase());
+            col.setDataType(rs1.getInt("DATA_TYPE"));
+            col.setDataTypeName(rs1.getString("TYPE_NAME"));
+            col.setColumnSize(rs1.getInt("COLUMN_SIZE"));
+            col.setDecimalDigits(rs1.getInt("DECIMAL_DIGITS"));
+            col.setNumPrecRadix(rs1.getInt("NUM_PREC_RADIX"));
+            col.setNullAble(rs1.getInt("NULLABLE"));
+            col.setRemarks(rs1.getString("REMARKS"));
+            col.setColumnDef(rs1.getString("COLUMN_DEF"));
+            col.setSqlDataType(rs1.getInt("SQL_DATA_TYPE"));
+            col.setSqlDatetimeSub(rs1.getInt("SQL_DATETIME_SUB"));
+            col.setCharOctetLength(rs1.getInt("CHAR_OCTET_LENGTH"));
+            col.setOrdinalPosition(rs1.getInt("ORDINAL_POSITION"));
+            col.setIsNullAble(rs1.getString("IS_NULLABLE"));
+            col.setIsAutoincrement(rs1.getString("IS_AUTOINCREMENT"));
 
-		TableMeta tm = new TableMeta();
-		tm.setTableName(tableName);
-	
-		java.sql.ResultSet rs1 = dbmd.getColumns(catalogName, schemaName, tableName, "%");
-		while (rs1.next()) {
-			ColumnMeta col = new ColumnMeta();
-			col.setTableCat(rs1.getString("TABLE_CAT"));
-			col.setTableSchemaName(rs1.getString("TABLE_SCHEM"));
-			col.setTableName(rs1.getString("TABLE_NAME"));
-			col.setColumnName(rs1.getString("COLUMN_NAME").toUpperCase());
-			col.setDataType(rs1.getInt("DATA_TYPE"));
-			col.setDataTypeName(rs1.getString("TYPE_NAME"));
-			col.setColumnSize(rs1.getInt("COLUMN_SIZE"));
-			col.setDecimalDigits(rs1.getInt("DECIMAL_DIGITS"));
-			col.setNumPrecRadix(rs1.getInt("NUM_PREC_RADIX"));
-			col.setNullAble(rs1.getInt("NULLABLE"));
-			col.setRemarks(rs1.getString("REMARKS"));
-			col.setColumnDef(rs1.getString("COLUMN_DEF"));
-			col.setSqlDataType(rs1.getInt("SQL_DATA_TYPE"));
-			col.setSqlDatetimeSub(rs1.getInt("SQL_DATETIME_SUB"));
-			col.setCharOctetLength(rs1.getInt("CHAR_OCTET_LENGTH"));
-			col.setOrdinalPosition(rs1.getInt("ORDINAL_POSITION"));
-			col.setIsNullAble(rs1.getString("IS_NULLABLE"));
-			col.setIsAutoincrement(rs1.getString("IS_AUTOINCREMENT"));
+            tm.getAllColumns().put(col.getColumnName(), col);
+        }
 
-			tm.getAllColumns().put(col.getColumnName(), col);
-		}
+        java.sql.ResultSet rs2 = dbmd.getIndexInfo(catalogName, schemaName, tableName, false, true);
+        String indexName = "";
+        while (rs2.next()) {
+            indexName = rs2.getString("INDEX_NAME");
+            String colName = rs2.getString("COLUMN_NAME").toUpperCase();
+            ColumnMeta col = tm.getAllColumns().get(colName);
 
-		java.sql.ResultSet rs2 = dbmd.getIndexInfo(catalogName, schemaName, tableName, false, true);
-		String indexName = "";
-		while (rs2.next()) {
-			indexName = rs2.getString("INDEX_NAME");
-			String colName = rs2.getString("COLUMN_NAME").toUpperCase();
-			ColumnMeta col = tm.getAllColumns().get(colName);
+            if (tm.getAllIndexes().containsKey(indexName)) {
+                IndexMeta index = tm.getAllIndexes().get(indexName);
+                index.getValues().add(col);
+            } else {
+                IndexMeta index = new IndexMeta();
+                index.setIndexName(indexName);
+                index.setNonUnique(rs2.getBoolean("NON_UNIQUE"));
+                index.setIndexQualifier(rs2.getString("INDEX_QUALIFIER"));
+                index.setIndexName(rs2.getString("INDEX_NAME"));
+                index.setType(rs2.getShort("TYPE"));
+                index.setOrdinalPosition(rs2.getShort("ORDINAL_POSITION"));
+                index.setAscOrDesc(rs2.getString("ASC_OR_DESC"));
+                index.setCardinality(rs2.getInt("CARDINALITY"));
+                index.getValues().add(col);
+                if ("PRIMARY".equalsIgnoreCase(indexName) || indexName.equalsIgnoreCase(rsmd.getTableName(1) + "_pkey")) {
+                    index.setIndextype(IndexType.PRIMARY);
+                } else if (index.isNonUnique() == false) {
+                    index.setIndextype(IndexType.Unique);
+                } else {
+                    index.setIndextype(IndexType.Normal);
+                }
+                tm.getAllIndexes().put(indexName, index);
 
-			if (tm.getAllIndexes().containsKey(indexName)) {
-				IndexMeta index = tm.getAllIndexes().get(indexName);
-				index.getValues().add(col);
-			} else {
-				IndexMeta index = new IndexMeta();
-				index.setIndexName(indexName);
-				index.setNonUnique(rs2.getBoolean("NON_UNIQUE"));
-				index.setIndexQualifier(rs2.getString("INDEX_QUALIFIER"));
-				index.setIndexName(rs2.getString("INDEX_NAME"));
-				index.setType(rs2.getShort("TYPE"));
-				index.setOrdinalPosition(rs2.getShort("ORDINAL_POSITION"));
-				index.setAscOrDesc(rs2.getString("ASC_OR_DESC"));
-				index.setCardinality(rs2.getInt("CARDINALITY"));
-				index.getValues().add(col);
-				if ("PRIMARY".equalsIgnoreCase(indexName)||indexName.equalsIgnoreCase(rsmd.getTableName(1)+"_pkey")) {
-					index.setIndextype(IndexType.PRIMARY);
-				} else if (index.isNonUnique() == false) {
-					index.setIndextype(IndexType.Unique);
-				} else {
-					index.setIndextype(IndexType.Normal);
-				}
-				tm.getAllIndexes().put(indexName, index);
-
-			}
-		}
-		IndexMeta index = tm.getAllIndexes().get(indexName);
-		if (index.getIndextype().value() != 0) {
-			if ("H2 JDBC Driver".equals(dbmd.getDriverName())) {
-				if (indexName.length() > 11 && "PRIMARY_KEY".equalsIgnoreCase(indexName.substring(0, 11))) {
-					index.setIndextype(IndexType.PRIMARY);
-				}
-			} else if (dbmd.getDriverName() != null && dbmd.getDriverName().toLowerCase().indexOf("postgresql") >= 0) {
-				if ((tableName + "_pkey").equalsIgnoreCase(indexName)) {
-					index.setIndextype(IndexType.PRIMARY);
-				}
-			}
-		}
-		return tm;
-	}
+            }
+        }
+        IndexMeta index = tm.getAllIndexes().get(indexName);
+        if (index.getIndextype().value() != 0) {
+            if ("H2 JDBC Driver".equals(dbmd.getDriverName())) {
+                if (indexName.length() > 11 && "PRIMARY_KEY".equalsIgnoreCase(indexName.substring(0, 11))) {
+                    index.setIndextype(IndexType.PRIMARY);
+                }
+            } else if (dbmd.getDriverName() != null && dbmd.getDriverName().toLowerCase().indexOf("postgresql") >= 0) {
+                if ((tableName + "_pkey").equalsIgnoreCase(indexName)) {
+                    index.setIndextype(IndexType.PRIMARY);
+                }
+            }
+        }
+        return tm;
+    }
 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/undo/SQLUndoLog.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/undo/SQLUndoLog.java
@@ -20,9 +20,13 @@ import com.alibaba.fescar.rm.datasource.sql.SQLType;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableMeta;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
 
+import java.util.List;
+
 public class SQLUndoLog {
 
     private SQLType sqlType;
+
+    private List<String> sqlHints;
 
     private String tableName;
 
@@ -45,6 +49,14 @@ public class SQLUndoLog {
 
     public void setSqlType(SQLType sqlType) {
         this.sqlType = sqlType;
+    }
+
+    public List<String> getSqlHints() {
+        return sqlHints;
+    }
+
+    public void setSqlHints(List<String> hints) {
+        this.sqlHints = hints;
     }
 
     public String getTableName() {

--- a/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/plugin/PluginManagerTest.java
+++ b/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/plugin/PluginManagerTest.java
@@ -1,0 +1,177 @@
+package com.alibaba.fescar.rm.datasource.plugin;
+
+import com.alibaba.fescar.rm.datasource.plugin.context.LockKeyBuildAfterContext;
+import com.alibaba.fescar.rm.datasource.plugin.context.SqlBuildAfterContext;
+import com.alibaba.fescar.rm.datasource.plugin.context.TableMetaBeforeContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PluginManagerTest {
+
+    private PluginManager pluginManager;
+
+    @Before
+    public void init() {
+        pluginManager = new PluginManager();
+    }
+
+    @Test
+    public void testSqlBuildAfter() {
+        String hint1 = "/*!mycat:schema=wz_buss_001*/";
+        List<String> hints = Arrays.asList(hint1);
+        String originSql = "select * from buss_user_info";
+
+        String result = pluginManager.execSqlBuildAfter(hints, originSql);
+        System.out.println(result);
+        Assert.assertTrue(result.equals(originSql));
+
+        pluginManager.addPlugins(new SqlBuildAfterPlugin());
+        result = pluginManager.execSqlBuildAfter(hints, originSql);
+        System.out.println(result);
+        Assert.assertTrue(result.startsWith(hint1));
+        Assert.assertTrue(result.endsWith(originSql));
+    }
+
+    @Test
+    public void testTableMetaBefore() {
+        String hint1 = "/*!mycat:schema=wz_buss_001*/";
+        List<String> hints = Arrays.asList(hint1);
+        String originSql = "select * from buss_user_info limit 1";
+
+        String cacheKey = "mysql://localhost:3306/demo.buss_user_info";
+        String metaQuerySql = originSql;
+
+        TableMetaBeforeContext ctx = pluginManager.execTableMetaBefore(hints, "buss_user_info", cacheKey, metaQuerySql);
+        System.out.println(cacheKey + " -> " + metaQuerySql);
+        Assert.assertTrue(cacheKey.equals(ctx.getResultForCacheKey()));
+        Assert.assertTrue(metaQuerySql.equals(ctx.getResultForMetaQuerySql()));
+
+        pluginManager.addPlugins(new TableMetaBeforePlugin());
+        ctx = pluginManager.execTableMetaBefore(hints, "buss_user_info", cacheKey, metaQuerySql);
+        System.out.println(ctx.getResultForCacheKey() + " -> " + ctx.getResultForMetaQuerySql());
+        Assert.assertTrue(ctx.getResultForCacheKey().equals("wz_buss_001." + cacheKey));
+        Assert.assertTrue(ctx.getResultForMetaQuerySql().startsWith(hint1) && ctx.getResultForMetaQuerySql().endsWith(originSql));
+    }
+
+    @Test
+    public void testLockKeyBuildAfter() {
+        String hint1 = "/*!mycat:schema=wz_buss_001*/";
+        List<String> hints = Arrays.asList(hint1);
+        String lockKey = "buss_user_info:1,2,3";
+
+        String result = pluginManager.execSqlBuildAfter(hints, lockKey);
+        System.out.println(result);
+        Assert.assertTrue(result.equals(lockKey));
+
+        pluginManager.addPlugins(new LockKeyBuildAfterPlugin());
+        result = pluginManager.execLockKeyBuildAfter(hints, null, lockKey);
+        System.out.println(result);
+        Assert.assertTrue(result.equals("wz_buss_001." + lockKey));
+    }
+
+    static class LockKeyBuildAfterPlugin implements Plugin {
+
+        @Override
+        public List<String> supportedActions() {
+            return Arrays.asList(PluginConstants.ACTION_LOCK_KEY_BUILD_AFTER);
+        }
+
+        @Override
+        public Object proc(PluginContext context) {
+            LockKeyBuildAfterContext ctx = (LockKeyBuildAfterContext) context;
+            List<String> sqlHints = ctx.getSqlHints();
+            String schema = resolveSchema(sqlHints);
+            String lockKey = ctx.getResultLockKey();
+            if (schema != "") {
+                return schema + "." + lockKey;
+            } else {
+                return lockKey;
+            }
+        }
+
+        private String resolveSchema(List<String> sqlHints) {
+            String schema = "";
+            for (String hint : sqlHints) {
+                Matcher matcher = pattern.matcher(hint);
+                if (matcher.find()) {
+                    schema = matcher.group(1);
+                }
+            }
+            return schema;
+        }
+
+        private static final Pattern pattern = Pattern.compile("schema=([0-9a-zA-Z_]{1,})");
+
+    }
+
+    static class SqlBuildAfterPlugin implements Plugin {
+
+        @Override
+        public List<String> supportedActions() {
+            return Arrays.asList(PluginConstants.ACTION_SQL_BUILD_AFTER);
+        }
+
+        @Override
+        public Object proc(PluginContext context) {
+            SqlBuildAfterContext ctx = (SqlBuildAfterContext) context;
+            String originSql = ctx.getResultSql();
+            List<String> sqlHints = ctx.getSqlHints();
+            StringBuilder sqlTxt = new StringBuilder();
+            for (Integer i = 0; i < sqlHints.size(); i++) {
+                sqlTxt.append(sqlHints.get(i));
+            }
+            return sqlTxt.toString() + " " + originSql;
+        }
+    }
+
+    static class TableMetaBeforePlugin implements Plugin {
+
+        @Override
+        public List<String> supportedActions() {
+            return Arrays.asList(PluginConstants.ACTION_TABLE_META_BEFORE);
+        }
+
+        @Override
+        public Object proc(PluginContext context) {
+            TableMetaBeforeContext ctx = (TableMetaBeforeContext) context;
+            String cacheKey = ctx.getResultForCacheKey();
+            String metaQuerySql = ctx.getResultForMetaQuerySql();
+            List<String> sqlHints = ctx.getSqlHints();
+
+            String schema = resolveSchema(sqlHints);
+            StringBuilder sqlTxt = new StringBuilder();
+            for (Integer i = 0; i < sqlHints.size(); i++) {
+                sqlTxt.append(sqlHints.get(i));
+            }
+            metaQuerySql = sqlTxt.toString() + " " + metaQuerySql;
+
+            if (schema != "") {
+                cacheKey = schema + "." + cacheKey;
+            }
+
+            ctx.setResultData(cacheKey, metaQuerySql);
+            return ctx.getResult();
+        }
+
+        private String resolveSchema(List<String> sqlHints) {
+            String schema = "";
+            for (String hint : sqlHints) {
+                Matcher matcher = pattern.matcher(hint);
+                if (matcher.find()) {
+                    schema = matcher.group(1);
+                }
+            }
+            return schema;
+        }
+
+        private static final Pattern pattern = Pattern.compile("schema=([0-9a-zA-Z_]{1,})");
+    }
+
+
+}

--- a/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/sql/SQLVisitorFactoryTest.java
+++ b/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/sql/SQLVisitorFactoryTest.java
@@ -1,0 +1,15 @@
+package com.alibaba.fescar.rm.datasource.sql;
+
+import com.alibaba.druid.util.JdbcConstants;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SQLVisitorFactoryTest {
+    @Test
+    public void testMysqlVisitor() {
+        String sql = "/*!mycat:schema=wz_buss_001*/ select * from buss_user_info";
+        SQLRecognizer recognizer = SQLVisitorFactory.get(sql, JdbcConstants.MYSQL);
+        Assert.assertTrue(recognizer.getSqlHints().size() == 1);
+        Assert.assertTrue(recognizer.getSQLType() == SQLType.SELECT_FOR_UPDATE);
+    }
+}

--- a/test/src/main/resources/basic-test-context.xml
+++ b/test/src/main/resources/basic-test-context.xml
@@ -20,9 +20,9 @@
 
 	<bean name="mysqlDataSource" class="com.alibaba.druid.pool.DruidDataSource"
 		  init-method="init" destroy-method="close">
-		<property name="url" value="jdbc:mysql://192.168.1.200:3306/demo"/>
-		<property name="username" value="wz_chain"/>
-		<property name="password" value="wz_chain@3c*111"/>
+		<property name="url" value="jdbc:mysql://XXXX:3306/demo"/>
+		<property name="username" value="XXXXX"/>
+		<property name="password" value="XXXX"/>
 		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
 		<property name="initialSize" value="0" />
 		<property name="maxActive" value="180" />


### PR DESCRIPTION
#120 对于hint开头的sql的支持, 提供一个参考处理方案.
考虑到将DB路由信息包含在hint的业务场景, 在rm-datasource中需要在lockKey的构建,undolog的处理上进行改造, 如mycat这样的中间件, db_schema是包含在hint中, 所以lockKey的构建就不能只考虑sql中的表数据信息, 另外在undo节点,也是需要undolog中保留原始sql中的hint信息,才能在正确的schem中执行undo.

这里的方案是在rm-resource中增加插件机制, 在lockKey和undolog的处理上增加应用能介入的点,具体改造主要如下:
1. undolog中增加sqlHints, 以用于undo阶段的处理
2. BaseRecognizer中增加sqlHints, 以用于事务执行阶段的处理
3. 将buildLockKey和prepareUndoLog从ConnectionProxy转移到BaseTransactionalExecutor中
4. 定义了plugin包, 增加plugin接口和相关实现类(lockKey后处理,sql后处理).管理类
5. 在BaseTransactionalExecutor增加lockKey构建的后处理
6. 在BaseTransactionalExecutor各个子类的sql执行前增加SQL构建后处理

目前单元测试只做了一个:
UndoExecutorTest.testUpdateWithPlugin
 

