### PR TITLE
ths isSending flag should be set as volatile type for multi-thread read and write without synchronized

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemoting.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemoting.java
@@ -96,7 +96,7 @@ public abstract class AbstractRpcRemoting extends ChannelDuplexHandler {
     /**
      * The Is sending.
      */
-    protected boolean isSending = false;
+    protected volatile boolean isSending = false;
     private String group = "DEFAULT";
     /**
      * The Merge msg map.


### PR DESCRIPTION
ths isSending flag should be set as volatile type for multi-thread read and write without synchronized