### PR TITLE
delete useless fescar-common in fescar-core because fescar-config had imported it

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>fescar-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fescar-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
         </dependency>


### PR DESCRIPTION
Signed-off-by: zhengyangyong <zhengyangyong@yunlizhihui.com>

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

delete useless fescar-common in fescar-core because fescar-config had imported it

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

mvn install local and use fescar-sample  verify it (change version to <fescar.version>0.1.4-SNAPSHOT</fescar.version>)

### Ⅴ. Special notes for reviews

