### PR TITLE
Fixed issue #387: UUIDGenerator Algorithm bug

### DIFF
--- a/server/src/main/java/com/alibaba/fescar/server/UUIDGenerator.java
+++ b/server/src/main/java/com/alibaba/fescar/server/UUIDGenerator.java
@@ -30,8 +30,8 @@ import com.alibaba.fescar.common.exception.ShouldNeverHappenException;
 public class UUIDGenerator {
 
     private static AtomicLong UUID = new AtomicLong(1000);
-
-    private static int UUID_INTERNAL = 2000000000;
+    private static int serverNodeId = 1;
+    private static final long UUID_INTERNAL = 2000000000;
 
     /**
      * Generate uuid long.
@@ -40,7 +40,7 @@ public class UUIDGenerator {
      */
     public static long generateUUID() {
         long id = UUID.incrementAndGet();
-        if (id > UUID_INTERNAL) {
+        if (id > UUID_INTERNAL * serverNodeId) {
             synchronized (UUID) {
                 if (UUID.get() >= id) {
                     id -= UUID_INTERNAL;
@@ -58,6 +58,7 @@ public class UUIDGenerator {
      */
     public static void init(int serverNodeId) {
         try {
+            UUIDGenerator.serverNodeId = serverNodeId;
             UUID.set(UUID_INTERNAL * serverNodeId);
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
             Calendar cal = Calendar.getInstance();

--- a/server/src/test/java/com/alibaba/fescar/server/UUIDGeneratorOverflowTest.java
+++ b/server/src/test/java/com/alibaba/fescar/server/UUIDGeneratorOverflowTest.java
@@ -1,0 +1,16 @@
+package com.alibaba.fescar.server;
+
+import org.testng.annotations.Test;
+
+public class UUIDGeneratorOverflowTest {
+    private static final int UUID_GENERATE_COUNT = 5;
+    private static final int SERVER_NODE_ID = 2;
+
+    @Test
+    public void testGenerateUUID() {
+        UUIDGenerator.init(SERVER_NODE_ID);
+        for (int i = 0; i < UUID_GENERATE_COUNT; i++) {
+            System.out.println("[UUID " + i + "] is: "+ UUIDGenerator.generateUUID());
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Fixed UUIDGenerator Algorithm bug: when the nodeId is greater than 1, it will not work as expected.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #387

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
unit test also included

### Ⅳ. Describe how to verify it
run the unit test UUIDGeneratorOverflowTest

### Ⅴ. Special notes for reviews

