### PR TITLE
NettyClientConfig Class member variable named incorrectly

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyClientConfig.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyClientConfig.java
@@ -51,7 +51,7 @@ public class NettyClientConfig extends NettyBaseConfig {
     private static final int DEFAULT_MIN_POOL_IDLE = 0;
     private static final boolean DEFAULT_POOL_TEST_BORROW = true;
     private static final boolean DEFAULT_POOL_TEST_RETURN = true;
-    private static final boolean DEFAULT_POOL_FIFO = true;
+    private static final boolean DEFAULT_POOL_LIFO = true;
 
     /**
      * Gets connect timeout millis.
@@ -423,8 +423,8 @@ public class NettyClientConfig extends NettyBaseConfig {
      *
      * @return the boolean
      */
-    public boolean isPoolFifo() {
-        return DEFAULT_POOL_FIFO;
+    public boolean isPoolLifo() {
+        return DEFAULT_POOL_LIFO;
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/RmRpcClient.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/RmRpcClient.java
@@ -190,7 +190,7 @@ public final class RmRpcClient extends AbstractRpcRemotingClient {
         poolConfig.maxWait = rmClientConfig.getMaxAcquireConnMills();
         poolConfig.testOnBorrow = rmClientConfig.isPoolTestBorrow();
         poolConfig.testOnReturn = rmClientConfig.isPoolTestReturn();
-        poolConfig.lifo = rmClientConfig.isPoolFifo();
+        poolConfig.lifo = rmClientConfig.isPoolLifo();
         return poolConfig;
     }
 

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/TmRpcClient.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/TmRpcClient.java
@@ -83,7 +83,7 @@ public final class TmRpcClient extends AbstractRpcRemotingClient {
     private final AtomicBoolean initialized = new AtomicBoolean(false);
     private String applicationId;
     private String transactionServiceGroup;
-    private final NettyClientConfig nettyClientConfig;
+    private final NettyClientConfig tmClientConfig;
     private final ConcurrentMap<String, NettyPoolKey> poolKeyMap
         = new ConcurrentHashMap<String, NettyPoolKey>();
     /**
@@ -95,7 +95,7 @@ public final class TmRpcClient extends AbstractRpcRemotingClient {
                         EventExecutorGroup eventExecutorGroup,
                         ThreadPoolExecutor messageExecutor) {
         super(nettyClientConfig, eventExecutorGroup, messageExecutor);
-        this.nettyClientConfig = nettyClientConfig;
+        this.tmClientConfig = nettyClientConfig;
     }
 
     /**
@@ -357,12 +357,12 @@ public final class TmRpcClient extends AbstractRpcRemotingClient {
     @Override
     protected Config getNettyPoolConfig() {
         Config poolConfig = new Config();
-        poolConfig.maxActive = nettyClientConfig.getMaxPoolActive();
-        poolConfig.minIdle = nettyClientConfig.getMinPoolIdle();
-        poolConfig.maxWait = nettyClientConfig.getMaxAcquireConnMills();
-        poolConfig.testOnBorrow = nettyClientConfig.isPoolTestBorrow();
-        poolConfig.testOnReturn = nettyClientConfig.isPoolTestReturn();
-        poolConfig.lifo = nettyClientConfig.isPoolFifo();
+        poolConfig.maxActive = tmClientConfig.getMaxPoolActive();
+        poolConfig.minIdle = tmClientConfig.getMinPoolIdle();
+        poolConfig.maxWait = tmClientConfig.getMaxAcquireConnMills();
+        poolConfig.testOnBorrow = tmClientConfig.isPoolTestBorrow();
+        poolConfig.testOnReturn = tmClientConfig.isPoolTestReturn();
+        poolConfig.lifo = tmClientConfig.isPoolLifo();
         return poolConfig;
     }
 

--- a/core/src/test/java/com/alibaba/fescar/core/rpc/netty/TmRpcClientTest.java
+++ b/core/src/test/java/com/alibaba/fescar/core/rpc/netty/TmRpcClientTest.java
@@ -60,7 +60,7 @@ public class TmRpcClientTest {
         Assert.assertEquals(defaultNettyClientConfig.getMaxAcquireConnMills(), config.maxWait);
         Assert.assertEquals(defaultNettyClientConfig.isPoolTestBorrow(), config.testOnBorrow);
         Assert.assertEquals(defaultNettyClientConfig.isPoolTestReturn(), config.testOnReturn);
-        Assert.assertEquals(defaultNettyClientConfig.isPoolFifo(), config.lifo);
+        Assert.assertEquals(defaultNettyClientConfig.isPoolLifo(), config.lifo);
     }
 
     /**


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Rename the member variable DEFAULT_POOL_FIFO in the NettyClientConfig class, Because the config object is actually assigned to a LIFO rather than a FIFO
### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Because it already exists

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
