### PR TITLE
fixes #522.Use File.separator instead of Hardcoded file separator.

### DIFF
--- a/server/src/main/java/com/alibaba/fescar/server/session/SessionHolder.java
+++ b/server/src/main/java/com/alibaba/fescar/server/session/SessionHolder.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fescar.server.session;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -58,8 +59,8 @@ public class SessionHolder {
             RETRY_COMMITTING_SESSION_MANAGER = new DefaultSessionManager(RETRY_COMMITTING_SESSION_MANAGER_NAME);
             RETRY_ROLLBACKING_SESSION_MANAGER = new DefaultSessionManager(RETRY_ROLLBACKING_SESSION_MANAGER_NAME);
         } else {
-            if (!sessionStorePath.endsWith("/")) {
-                sessionStorePath = sessionStorePath + "/";
+            if (!sessionStorePath.endsWith(File.separator)) {
+                sessionStorePath = sessionStorePath + File.separator;
             }
             ROOT_SESSION_MANAGER = new FileBasedSessionManager(ROOT_SESSION_MANAGER_NAME, sessionStorePath);
             ASYNC_COMMITTING_SESSION_MANAGER = new DefaultSessionManager(ASYNC_COMMITTING_SESSION_MANAGER_NAME);

--- a/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
+++ b/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
@@ -1,13 +1,26 @@
+/*
+ *  Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.alibaba.fescar.server.session;
 
 
-import org.apache.commons.io.FileUtils;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 /**
  * @author Wu

--- a/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
+++ b/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
@@ -1,0 +1,19 @@
+package com.alibaba.fescar.server.session;
+
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+/**
+ * @author Wu
+ * @date 2019/3/6
+ * xingfudeshi@gmail.com
+ * The type Session holder test.
+ */
+public class SessionHolderTest {
+
+    @Test
+    public void testInit() throws IOException {
+        SessionHolder.init("D:\\sessionStore");
+    }
+}

--- a/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
+++ b/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
@@ -16,12 +16,9 @@
 
 package com.alibaba.fescar.server.session;
 
-
 import org.testng.annotations.Test;
-
 import static com.alibaba.fescar.server.session.SessionHolder.ROOT_SESSION_MANAGER_NAME;
 import static org.assertj.core.api.Assertions.*;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -34,20 +31,17 @@ public class SessionHolderTest {
 
     @Test
     public void testInit() throws IOException {
-        String sessionStorePath=System.getProperty("user.dir")+ File.separator +"sessionStore";
+        String sessionStorePath = System.getProperty("user.dir") + File.separator + "sessionStore";
         //delete file previously created
-        File rootSessionFile=new File(sessionStorePath+File.separator+ROOT_SESSION_MANAGER_NAME);
-        if(rootSessionFile.exists()){
+        File rootSessionFile = new File(sessionStorePath + File.separator + ROOT_SESSION_MANAGER_NAME);
+        if (rootSessionFile.exists()) {
             rootSessionFile.delete();
         }
-        File file=new File(sessionStorePath);
-        if(!file.exists()&&!file.isDirectory()){
+        File file = new File(sessionStorePath);
+        if (!file.exists() && !file.isDirectory()) {
             file.mkdirs();
         }
         SessionHolder.init(sessionStorePath);
-
-        assertThat(new File(sessionStorePath+File.separator+ROOT_SESSION_MANAGER_NAME)).exists().isFile();
-
-
+        assertThat(new File(sessionStorePath + File.separator + ROOT_SESSION_MANAGER_NAME)).exists().isFile();
     }
 }

--- a/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
+++ b/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
@@ -1,9 +1,14 @@
 package com.alibaba.fescar.server.session;
 
 
+import org.apache.commons.io.FileUtils;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 /**
  * @author Wu
  * @date 2019/3/6
@@ -14,6 +19,11 @@ public class SessionHolderTest {
 
     @Test
     public void testInit() throws IOException {
-        SessionHolder.init("D:\\sessionStore");
+        String sessionStorePath=System.getProperty("user.dir")+ File.separator +"sessionStore";
+        File file=new File(sessionStorePath);
+        if(!file.exists()&&!file.isDirectory()){
+            file.mkdirs();
+        }
+        SessionHolder.init(sessionStorePath);
     }
 }

--- a/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
+++ b/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
@@ -19,13 +19,15 @@ package com.alibaba.fescar.server.session;
 
 import org.testng.annotations.Test;
 
+import static com.alibaba.fescar.server.session.SessionHolder.ROOT_SESSION_MANAGER_NAME;
+import static org.assertj.core.api.Assertions.*;
+
 import java.io.File;
 import java.io.IOException;
 
 /**
  * @author Wu
  * @date 2019/3/6
- * xingfudeshi@gmail.com
  * The type Session holder test.
  */
 public class SessionHolderTest {
@@ -33,10 +35,19 @@ public class SessionHolderTest {
     @Test
     public void testInit() throws IOException {
         String sessionStorePath=System.getProperty("user.dir")+ File.separator +"sessionStore";
+        //delete file previously created
+        File rootSessionFile=new File(sessionStorePath+File.separator+ROOT_SESSION_MANAGER_NAME);
+        if(rootSessionFile.exists()){
+            rootSessionFile.delete();
+        }
         File file=new File(sessionStorePath);
         if(!file.exists()&&!file.isDirectory()){
             file.mkdirs();
         }
         SessionHolder.init(sessionStorePath);
+
+        assertThat(new File(sessionStorePath+File.separator+ROOT_SESSION_MANAGER_NAME)).exists().isFile();
+
+
     }
 }

--- a/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
+++ b/server/src/test/java/com/alibaba/fescar/server/session/SessionHolderTest.java
@@ -16,9 +16,11 @@
 
 package com.alibaba.fescar.server.session;
 
-import org.testng.annotations.Test;
+import org.junit.Test;
+
 import static com.alibaba.fescar.server.session.SessionHolder.ROOT_SESSION_MANAGER_NAME;
 import static org.assertj.core.api.Assertions.*;
+
 import java.io.File;
 import java.io.IOException;
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Uses hardcoded file separator will cause cross-platform file path problems,so we must use some way platform independent to avoid it.Uses File.separator is one of the best way.
fixes #522.Use File.separator instead of Hardcoded file separator.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #522

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
i have added a unit test

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
I have searched all code block,ensure that only this code has this problem so far.
