### PR TITLE
fix #489 when GlobalRollback but not receive report

### DIFF
--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/undo/UndoLogManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/undo/UndoLogManager.java
@@ -16,12 +16,6 @@
 
 package com.alibaba.fescar.rm.datasource.undo;
 
-import java.sql.Blob;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 import com.alibaba.druid.util.JdbcConstants;
 import com.alibaba.fescar.common.exception.NotSupportYetException;
 import com.alibaba.fescar.common.util.BlobUtils;
@@ -32,7 +26,12 @@ import com.alibaba.fescar.rm.datasource.ConnectionProxy;
 import com.alibaba.fescar.rm.datasource.DataSourceProxy;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableMeta;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableMetaCache;
-
+import java.sql.Blob;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +41,27 @@ import static com.alibaba.fescar.core.exception.TransactionExceptionCode.BranchR
  * The type Undo log manager.
  */
 public final class UndoLogManager {
+    private enum State {
+        /**
+         * This state can be properly rolled back by fescar
+         */
+        Normal(0),
+        /**
+         * This state prevents the branch transaction from inserting undo_log after the global transaction is rolled
+         * back.
+         */
+        GlobalFinished(1);
+
+        private int value;
+
+        State(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UndoLogManager.class);
 
@@ -49,12 +69,12 @@ public final class UndoLogManager {
 
     private static String INSERT_UNDO_LOG_SQL = "INSERT INTO " + UNDO_LOG_TABLE_NAME + "\n" +
         "\t(branch_id, xid, rollback_info, log_status, log_created, log_modified)\n" +
-        "VALUES (?, ?, ?, 0, now(), now())";
+        "VALUES (?, ?, ?, ?, now(), now())";
     private static String DELETE_UNDO_LOG_SQL = "DELETE FROM " + UNDO_LOG_TABLE_NAME + "\n" +
         "\tWHERE branch_id = ? AND xid = ?";
 
     private static String SELECT_UNDO_LOG_SQL = "SELECT * FROM " + UNDO_LOG_TABLE_NAME
-        + " WHERE log_status = 0 AND branch_id = ? AND xid = ? FOR UPDATE";
+        + " WHERE  branch_id = ? AND xid = ? FOR UPDATE";
 
     private UndoLogManager() {
 
@@ -84,25 +104,7 @@ public final class UndoLogManager {
             LOGGER.debug("Flushing UNDO LOG: " + undoLogContent);
         }
 
-        PreparedStatement pst = null;
-        try {
-            pst = cp.getTargetConnection().prepareStatement(INSERT_UNDO_LOG_SQL);
-            pst.setLong(1, branchID);
-            pst.setString(2, xid);
-            pst.setBlob(3, BlobUtils.string2blob(undoLogContent));
-            pst.executeUpdate();
-        } catch (Exception e) {
-            if (e instanceof SQLException) {
-                throw (SQLException)e;
-            } else {
-                throw new SQLException(e);
-            }
-        } finally {
-            if (pst != null) {
-                pst.close();
-            }
-        }
-
+        insertUndoLogWithNormal(xid, branchID, undoLogContent, cp.getTargetConnection());
     }
 
     private static void assertDbSupport(String dbType) {
@@ -115,8 +117,8 @@ public final class UndoLogManager {
      * Undo.
      *
      * @param dataSourceProxy the data source proxy
-     * @param xid             the xid
-     * @param branchId        the branch id
+     * @param xid the xid
+     * @param branchId the branch id
      * @throws TransactionException the transaction exception
      */
     public static void undo(DataSourceProxy dataSourceProxy, String xid, long branchId) throws TransactionException {
@@ -125,70 +127,107 @@ public final class UndoLogManager {
         Connection conn = null;
         ResultSet rs = null;
         PreparedStatement selectPST = null;
-        try {
-            conn = dataSourceProxy.getPlainConnection();
 
-            // The entire undo process should run in a local transaction.
-            conn.setAutoCommit(false);
-
-            // Find UNDO LOG
-            selectPST = conn.prepareStatement(SELECT_UNDO_LOG_SQL);
-            selectPST.setLong(1, branchId);
-            selectPST.setString(2, xid);
-            rs = selectPST.executeQuery();
-
-            while (rs.next()) {
-                Blob b = rs.getBlob("rollback_info");
-                String rollbackInfo = StringUtils.blob2string(b);
-                BranchUndoLog branchUndoLog = UndoLogParserFactory.getInstance().decode(rollbackInfo);
-
-                for (SQLUndoLog sqlUndoLog : branchUndoLog.getSqlUndoLogs()) {
-                    TableMeta tableMeta = TableMetaCache.getTableMeta(dataSourceProxy, sqlUndoLog.getTableName());
-                    sqlUndoLog.setTableMeta(tableMeta);
-                    AbstractUndoExecutor undoExecutor = UndoExecutorFactory.getUndoExecutor(dataSourceProxy.getDbType(),
-                        sqlUndoLog);
-                    undoExecutor.executeOn(conn);
-                }
-
-            }
-            deleteUndoLog(xid, branchId, conn);
-
-            conn.commit();
-
-        } catch (Throwable e) {
-            if (conn != null) {
-                try {
-                    conn.rollback();
-                } catch (SQLException rollbackEx) {
-                    LOGGER.warn("Failed to close JDBC resource while undo ... ", rollbackEx);
-                }
-            }
-            throw new TransactionException(BranchRollbackFailed_Retriable, String.format("%s/%s", branchId, xid), e);
-
-        } finally {
+        for (; ; ) {
             try {
-                if (rs != null) {
-                    rs.close();
+                conn = dataSourceProxy.getPlainConnection();
+
+                // The entire undo process should run in a local transaction.
+                conn.setAutoCommit(false);
+
+                // Find UNDO LOG
+                selectPST = conn.prepareStatement(SELECT_UNDO_LOG_SQL);
+                selectPST.setLong(1, branchId);
+                selectPST.setString(2, xid);
+                rs = selectPST.executeQuery();
+
+                boolean exists = false;
+                while (rs.next()) {
+                    exists = true;
+
+                    // It is possible that the server repeatedly sends a rollback request to roll back
+                    // the same branch transaction to multiple processes,
+                    // ensuring that only the undo_log in the normal state is processed.
+                    int state = rs.getInt("log_status");
+                    if (!canUndo(state)) {
+                        LOGGER.info("xid {} branch {}, ignore {} undo_log",
+                            xid, branchId, state);
+                        return;
+                    }
+
+                    Blob b = rs.getBlob("rollback_info");
+                    String rollbackInfo = StringUtils.blob2string(b);
+                    BranchUndoLog branchUndoLog = UndoLogParserFactory.getInstance().decode(rollbackInfo);
+
+                    for (SQLUndoLog sqlUndoLog : branchUndoLog.getSqlUndoLogs()) {
+                        TableMeta tableMeta = TableMetaCache.getTableMeta(dataSourceProxy, sqlUndoLog.getTableName());
+                        sqlUndoLog.setTableMeta(tableMeta);
+                        AbstractUndoExecutor undoExecutor = UndoExecutorFactory.getUndoExecutor(dataSourceProxy.getDbType(),
+                            sqlUndoLog);
+                        undoExecutor.executeOn(conn);
+                    }
                 }
-                if (selectPST != null) {
-                    selectPST.close();
+
+                // If undo_log exists, it means that the branch transaction has completed the first phase,
+                // we can directly roll back and clean the undo_log
+                // Otherwise, it indicates that there is an exception in the branch transaction,
+                // causing undo_log not to be written to the database.
+                // For example, the business processing timeout, the global transaction is the initiator rolls back.
+                // To ensure data consistency, we can insert an undo_log with GlobalFinished state
+                // to prevent the local transaction of the first phase of other programs from being correctly submitted.
+                // See https://github.com/alibaba/fescar/issues/489
+
+                if (exists) {
+                    deleteUndoLog(xid, branchId, conn);
+                    conn.commit();
+                    LOGGER.info("xid {} branch {}, undo_log deleted",
+                        xid, branchId, State.GlobalFinished.name());
+                } else {
+                    insertUndoLogWithGlobalFinished(xid, branchId, conn);
+                    conn.commit();
+                    LOGGER.info("xid {} branch {}, undo_log added with {}",
+                        xid, branchId, State.GlobalFinished.name());
                 }
+
+                return;
+            } catch (SQLIntegrityConstraintViolationException e) {
+                // Possible undo_log has been inserted into the database by other processes, retrying rollback undo_log
+                LOGGER.info("xid {} branch {}, undo_log inserted, retry rollback",
+                    xid, branchId);
+            } catch (Throwable e) {
                 if (conn != null) {
-                    conn.close();
+                    try {
+                        conn.rollback();
+                    } catch (SQLException rollbackEx) {
+                        LOGGER.warn("Failed to close JDBC resource while undo ... ", rollbackEx);
+                    }
                 }
-            } catch (SQLException closeEx) {
-                LOGGER.warn("Failed to close JDBC resource while undo ... ", closeEx);
+                throw new TransactionException(BranchRollbackFailed_Retriable, String.format("%s/%s", branchId, xid), e);
+
+            } finally {
+                try {
+                    if (rs != null) {
+                        rs.close();
+                    }
+                    if (selectPST != null) {
+                        selectPST.close();
+                    }
+                    if (conn != null) {
+                        conn.close();
+                    }
+                } catch (SQLException closeEx) {
+                    LOGGER.warn("Failed to close JDBC resource while undo ... ", closeEx);
+                }
             }
         }
-
     }
 
     /**
      * Delete undo log.
      *
-     * @param xid      the xid
+     * @param xid the xid
      * @param branchId the branch id
-     * @param conn     the conn
+     * @param conn the conn
      * @throws SQLException the sql exception
      */
     public static void deleteUndoLog(String xid, long branchId, Connection conn) throws SQLException {
@@ -196,5 +235,42 @@ public final class UndoLogManager {
         deletePST.setLong(1, branchId);
         deletePST.setString(2, xid);
         deletePST.executeUpdate();
+    }
+
+    private static void insertUndoLogWithNormal(String xid, long branchID,
+        String undoLogContent, Connection conn) throws SQLException {
+        insertUndoLog(xid, branchID, undoLogContent, State.Normal, conn);
+    }
+
+    private static void insertUndoLogWithGlobalFinished(String xid, long branchID,
+        Connection conn) throws SQLException {
+        insertUndoLog(xid, branchID, "{}", State.GlobalFinished, conn);
+    }
+
+    private static void insertUndoLog(String xid, long branchID,
+        String undoLogContent, State state, Connection conn) throws SQLException {
+        PreparedStatement pst = null;
+        try {
+            pst = conn.prepareStatement(INSERT_UNDO_LOG_SQL);
+            pst.setLong(1, branchID);
+            pst.setString(2, xid);
+            pst.setBlob(3, BlobUtils.string2blob(undoLogContent));
+            pst.setInt(4, state.getValue());
+            pst.executeUpdate();
+        } catch (Exception e) {
+            if (e instanceof SQLException) {
+                throw (SQLException) e;
+            } else {
+                throw new SQLException(e);
+            }
+        } finally {
+            if (pst != null) {
+                pst.close();
+            }
+        }
+    }
+
+    private static boolean canUndo(int state) {
+        return state == State.Normal.getValue();
     }
 }

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/undo/UndoLogManager.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/undo/UndoLogManager.java
@@ -180,7 +180,7 @@ public final class UndoLogManager {
                 if (exists) {
                     deleteUndoLog(xid, branchId, conn);
                     conn.commit();
-                    LOGGER.info("xid {} branch {}, undo_log deleted",
+                    LOGGER.info("xid {} branch {}, undo_log deleted with {}",
                         xid, branchId, State.GlobalFinished.name());
                 } else {
                     insertUndoLogWithGlobalFinished(xid, branchId, conn);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Fix #489 

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #489 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
A, B two processes, perform the following steps:
1. A initiates a global transaction
2. B registration branch transaction succeeded
3. B service processing time is greater than the RPC timeout period.
4. A receives the RPC timeout and initiates a global transaction rollback.
5. After the global transaction is rolled back, the business of B is processed.

### Ⅴ. Special notes for reviews

