### PR TITLE
fix #357 pk auto generated but value is null

### DIFF
--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
@@ -78,14 +78,14 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
         return afterImage;
     }
 
-    private boolean containsPK() {
+    protected boolean containsPK() {
         SQLInsertRecognizer recogizier = (SQLInsertRecognizer)sqlRecognizer;
         List<String> insertColumns = recogizier.getInsertColumns();
         TableMeta tmeta = getTableMeta();
         return tmeta.containsPK(insertColumns);
     }
 
-    private List<Object> getPkValuesByColumn() throws SQLException {
+    protected List<Object> getPkValuesByColumn() throws SQLException {
         // insert values including PK
         SQLInsertRecognizer recogizier = (SQLInsertRecognizer)sqlRecognizer;
         List<String> insertColumns = recogizier.getInsertColumns();
@@ -116,7 +116,7 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
     }
 
 
-    private List<Object> getPkValuesByAuto() throws SQLException {
+    protected List<Object> getPkValuesByAuto() throws SQLException {
         // PK is just auto generated
         Map<String, ColumnMeta> pkMetaMap = getTableMeta().getPrimaryKeyMap();
         if (pkMetaMap.size() != 1) {
@@ -148,7 +148,7 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
         return pkValues;
     }
 
-    private TableRecords getTableRecords(List<Object> pkValues) throws SQLException {
+    protected TableRecords getTableRecords(List<Object> pkValues) throws SQLException {
         TableRecords afterImage;
         String pk = getTableMeta().getPkName();
         StringBuffer selectSQLAppender = new StringBuffer("SELECT * FROM " + getTableMeta().getTableName() + " WHERE ");

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
@@ -45,7 +45,7 @@ import java.util.Map;
  */
 public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecutor<T, S> {
 
-    private static final String ERR_SQL_STATE = "S1009";
+    protected static final String ERR_SQL_STATE = "S1009";
 
     /**
      * Instantiates a new Insert executor.

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
@@ -16,14 +16,6 @@
 
 package com.alibaba.fescar.rm.datasource.exec;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.alibaba.fescar.common.exception.NotSupportYetException;
 import com.alibaba.fescar.common.exception.ShouldNeverHappenException;
 import com.alibaba.fescar.rm.datasource.PreparedStatementProxy;
@@ -31,8 +23,17 @@ import com.alibaba.fescar.rm.datasource.StatementProxy;
 import com.alibaba.fescar.rm.datasource.sql.SQLInsertRecognizer;
 import com.alibaba.fescar.rm.datasource.sql.SQLRecognizer;
 import com.alibaba.fescar.rm.datasource.sql.struct.ColumnMeta;
+import com.alibaba.fescar.rm.datasource.sql.struct.Null;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableMeta;
 import com.alibaba.fescar.rm.datasource.sql.struct.TableRecords;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The type Insert executor.
@@ -61,72 +62,86 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
 
     @Override
     protected TableRecords afterImage(TableRecords beforeImage) throws SQLException {
-        SQLInsertRecognizer recogizier = (SQLInsertRecognizer)sqlRecognizer;
-        List<String> insertColumns = recogizier.getInsertColumns();
-        TableMeta tmeta = getTableMeta();
-        TableRecords afterImage = null;
-        if (tmeta.containsPK(insertColumns)) {
-            // insert values including PK
-            List<Object> pkValues = null;
-            String pk = tmeta.getPkName();
-            for (int paramIdx = 0; paramIdx < insertColumns.size(); paramIdx++) {
-                if (insertColumns.get(paramIdx).equalsIgnoreCase(pk)) {
-                    if (statementProxy instanceof PreparedStatementProxy) {
-                        pkValues = ((PreparedStatementProxy)statementProxy).getParamsByIndex(paramIdx);
-                    } else {
-                        List<List<Object>> insertRows = recogizier.getInsertRows();
-                        pkValues = new ArrayList<>(insertRows.size());
-                        for (List<Object> row : insertRows) {
-                            pkValues.add(row.get(paramIdx));
-                        }
-                    }
-                    break;
-                }
-            }
-            if (pkValues == null) {
-                throw new ShouldNeverHappenException();
-            }
-            afterImage = getTableRecords(pkValues);
+        //Pk column exists or PK is just auto generated
+        List<Object> pkValues = containsPK()?getPkValuesByColumn():getPkValuesByAuto();
 
-        } else {
-            // PK is just auto generated
-            Map<String, ColumnMeta> pkMetaMap = getTableMeta().getPrimaryKeyMap();
-            if (pkMetaMap.size() != 1) {
-                throw new NotSupportYetException();
-            }
-            ColumnMeta pkMeta = pkMetaMap.values().iterator().next();
-            if (!pkMeta.isAutoincrement()) {
-                throw new ShouldNeverHappenException();
-            }
-
-            ResultSet genKeys = null;
-            try {
-                genKeys = statementProxy.getTargetStatement().getGeneratedKeys();
-            } catch (SQLException e) {
-                // java.sql.SQLException: Generated keys not requested. You need to
-                // specify Statement.RETURN_GENERATED_KEYS to
-                // Statement.executeUpdate() or Connection.prepareStatement().
-                if ("S1009".equalsIgnoreCase(e.getSQLState())) {
-                    genKeys = statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
-                } else {
-                    throw e;
-                }
-            }
-            List<Object> pkValues = new ArrayList<>();
-            while (genKeys.next()) {
-                Object v = genKeys.getObject(1);
-                pkValues.add(v);
-            }
-
-            afterImage = getTableRecords(pkValues);
-
-        }
+        TableRecords afterImage = getTableRecords(pkValues);
 
         if (afterImage == null) {
             throw new SQLException("Failed to build after-image for insert");
         }
 
         return afterImage;
+    }
+
+    private boolean containsPK() {
+        SQLInsertRecognizer recogizier = (SQLInsertRecognizer)sqlRecognizer;
+        List<String> insertColumns = recogizier.getInsertColumns();
+        TableMeta tmeta = getTableMeta();
+        return tmeta.containsPK(insertColumns);
+    }
+
+    private List<Object> getPkValuesByColumn() throws SQLException {
+        // insert values including PK
+        SQLInsertRecognizer recogizier = (SQLInsertRecognizer)sqlRecognizer;
+        List<String> insertColumns = recogizier.getInsertColumns();
+        String pk = getTableMeta().getPkName();
+        List<Object> pkValues = null;
+        for (int paramIdx = 0; paramIdx < insertColumns.size(); paramIdx++) {
+            if (insertColumns.get(paramIdx).equalsIgnoreCase(pk)) {
+                if (statementProxy instanceof PreparedStatementProxy) {
+                    pkValues = ((PreparedStatementProxy)statementProxy).getParamsByIndex(paramIdx);
+                } else {
+                    List<List<Object>> insertRows = recogizier.getInsertRows();
+                    pkValues = new ArrayList<>(insertRows.size());
+                    for (List<Object> row : insertRows) {
+                        pkValues.add(row.get(paramIdx));
+                    }
+                }
+                break;
+            }
+        }
+        if (pkValues == null) {
+            throw new ShouldNeverHappenException();
+        }
+        //pk auto generated while column exists and value is null
+        if (pkValues.size() == 1 && pkValues.get(0) instanceof Null) {
+            pkValues=getPkValuesByAuto();
+        }
+        return pkValues;
+    }
+
+
+    private List<Object> getPkValuesByAuto() throws SQLException {
+        // PK is just auto generated
+        Map<String, ColumnMeta> pkMetaMap=getTableMeta().getPrimaryKeyMap();
+        if (pkMetaMap.size() != 1) {
+            throw new NotSupportYetException();
+        }
+        ColumnMeta pkMeta=pkMetaMap.values().iterator().next();
+        if (!pkMeta.isAutoincrement()) {
+            throw new ShouldNeverHappenException();
+        }
+
+        ResultSet genKeys=null;
+        try {
+            genKeys=statementProxy.getTargetStatement().getGeneratedKeys();
+        } catch (SQLException e) {
+            // java.sql.SQLException: Generated keys not requested. You need to
+            // specify Statement.RETURN_GENERATED_KEYS to
+            // Statement.executeUpdate() or Connection.prepareStatement().
+            if ("S1009".equalsIgnoreCase(e.getSQLState())) {
+                genKeys=statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
+            } else {
+                throw e;
+            }
+        }
+        List<Object> pkValues=new ArrayList<>();
+        while (genKeys.next()) {
+            Object v=genKeys.getObject(1);
+            pkValues.add(v);
+        }
+        return pkValues;
     }
 
     private TableRecords getTableRecords(List<Object> pkValues) throws SQLException {

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
@@ -40,8 +40,12 @@ import java.util.Map;
  *
  * @param <T> the type parameter
  * @param <S> the type parameter
+ * @author yuanguoyao
+ * @date 2019-03-21 21:30:02
  */
 public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecutor<T, S> {
+
+    private static final String ERR_SQL_STATE = "S1009";
 
     /**
      * Instantiates a new Insert executor.
@@ -114,31 +118,31 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
 
     private List<Object> getPkValuesByAuto() throws SQLException {
         // PK is just auto generated
-        Map<String, ColumnMeta> pkMetaMap=getTableMeta().getPrimaryKeyMap();
+        Map<String, ColumnMeta> pkMetaMap = getTableMeta().getPrimaryKeyMap();
         if (pkMetaMap.size() != 1) {
             throw new NotSupportYetException();
         }
-        ColumnMeta pkMeta=pkMetaMap.values().iterator().next();
+        ColumnMeta pkMeta = pkMetaMap.values().iterator().next();
         if (!pkMeta.isAutoincrement()) {
             throw new ShouldNeverHappenException();
         }
 
-        ResultSet genKeys=null;
+        ResultSet genKeys = null;
         try {
-            genKeys=statementProxy.getTargetStatement().getGeneratedKeys();
+            genKeys = statementProxy.getTargetStatement().getGeneratedKeys();
         } catch (SQLException e) {
             // java.sql.SQLException: Generated keys not requested. You need to
             // specify Statement.RETURN_GENERATED_KEYS to
             // Statement.executeUpdate() or Connection.prepareStatement().
-            if ("S1009".equalsIgnoreCase(e.getSQLState())) {
-                genKeys=statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
+            if (ERR_SQL_STATE.equalsIgnoreCase(e.getSQLState())) {
+                genKeys = statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
             } else {
                 throw e;
             }
         }
-        List<Object> pkValues=new ArrayList<>();
+        List<Object> pkValues = new ArrayList<>();
         while (genKeys.next()) {
-            Object v=genKeys.getObject(1);
+            Object v = genKeys.getObject(1);
             pkValues.add(v);
         }
         return pkValues;

--- a/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutor.java
@@ -63,7 +63,7 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
     @Override
     protected TableRecords afterImage(TableRecords beforeImage) throws SQLException {
         //Pk column exists or PK is just auto generated
-        List<Object> pkValues = containsPK()?getPkValuesByColumn():getPkValuesByAuto();
+        List<Object> pkValues = containsPK() ? getPkValuesByColumn() : getPkValuesByAuto();
 
         TableRecords afterImage = getTableRecords(pkValues);
 
@@ -106,7 +106,7 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
         }
         //pk auto generated while column exists and value is null
         if (pkValues.size() == 1 && pkValues.get(0) instanceof Null) {
-            pkValues=getPkValuesByAuto();
+            pkValues = getPkValuesByAuto();
         }
         return pkValues;
     }

--- a/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
+++ b/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
@@ -111,7 +111,7 @@ public class InsertExecutorTest {
         Assertions.assertThat(resultTableRecords).isEqualTo(tableRecords);
     }
 
-    @Test(expected=SQLException.class)
+    @Test(expected = SQLException.class)
     public void testAfterImage_Exception() throws SQLException {
         doReturn(false).when(insertExecutor).containsPK();
         List<Object> pkValues = new ArrayList<>();
@@ -143,7 +143,7 @@ public class InsertExecutorTest {
         Assertions.assertThat(pkValuesByColumn).isEqualTo(pkValues);
     }
 
-    @Test(expected =ShouldNeverHappenException.class)
+    @Test(expected = ShouldNeverHappenException.class)
     public void testGetPkValuesByColumn_Exception() throws SQLException {
         mockInsertColumns();
         doReturn(tableMeta).when(insertExecutor).getTableMeta();
@@ -170,7 +170,7 @@ public class InsertExecutorTest {
         Assertions.assertThat(pkValuesByColumn).isEqualTo(pkValuesAuto);
     }
 
-    @Test(expected =NotSupportYetException.class)
+    @Test(expected = NotSupportYetException.class)
     public void testGetPkValuesByAuto_NotSupportYetException() throws SQLException {
         doReturn(tableMeta).when(insertExecutor).getTableMeta();
         Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
@@ -180,7 +180,7 @@ public class InsertExecutorTest {
         insertExecutor.getPkValuesByAuto();
     }
 
-    @Test(expected =ShouldNeverHappenException.class)
+    @Test(expected = ShouldNeverHappenException.class)
     public void testGetPkValuesByAuto_ShouldNeverHappenException() throws SQLException {
         doReturn(tableMeta).when(insertExecutor).getTableMeta();
         Map<String, ColumnMeta> columnMetaMap = new HashMap<>();

--- a/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
+++ b/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
@@ -215,11 +215,11 @@ public class InsertExecutorTest {
         when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
-        ResultSet resultSet=mock(ResultSet.class);
+        ResultSet resultSet = mock(ResultSet.class);
         when(preparedStatement.getGeneratedKeys()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(false);
         when(resultSet.getObject(1)).thenReturn(PK_VALUE);
-        List pkValuesByAuto=insertExecutor.getPkValuesByAuto();
+        List pkValuesByAuto = insertExecutor.getPkValuesByAuto();
         Assertions.assertThat(pkValuesByAuto).isEmpty();
     }
 
@@ -233,13 +233,13 @@ public class InsertExecutorTest {
         when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
-        ResultSet resultSet=mock(ResultSet.class);
+        ResultSet resultSet = mock(ResultSet.class);
         when(preparedStatement.getGeneratedKeys()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true).thenReturn(false);
         when(resultSet.getObject(1)).thenReturn(PK_VALUE);
         List<Object> pkValues = new ArrayList<>();
         pkValues.add(PK_VALUE);
-        List pkValuesByAuto=insertExecutor.getPkValuesByAuto();
+        List pkValuesByAuto = insertExecutor.getPkValuesByAuto();
         Assertions.assertThat(pkValuesByAuto).isEqualTo(pkValues);
     }
 
@@ -254,13 +254,13 @@ public class InsertExecutorTest {
         PreparedStatement preparedStatement = mock(PreparedStatement.class);
         when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
         when(preparedStatement.getGeneratedKeys()).thenThrow(new SQLException("", InsertExecutor.ERR_SQL_STATE));
-        ResultSet resultSet=mock(ResultSet.class);
+        ResultSet resultSet = mock(ResultSet.class);
         when(preparedStatement.executeQuery(anyString())).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true).thenReturn(false);
         when(resultSet.getObject(1)).thenReturn(PK_VALUE);
         List<Object> pkValues = new ArrayList<>();
         pkValues.add(PK_VALUE);
-        List pkValuesByAuto=insertExecutor.getPkValuesByAuto();
+        List pkValuesByAuto = insertExecutor.getPkValuesByAuto();
         Assertions.assertThat(pkValuesByAuto).isEqualTo(pkValues);
     }
 

--- a/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
+++ b/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
@@ -1,0 +1,105 @@
+package com.alibaba.fescar.rm.datasource.exec;
+
+import com.alibaba.fescar.common.exception.ShouldNeverHappenException;
+import com.alibaba.fescar.rm.datasource.PreparedStatementProxy;
+import com.alibaba.fescar.rm.datasource.sql.SQLInsertRecognizer;
+import com.alibaba.fescar.rm.datasource.sql.struct.Null;
+import com.alibaba.fescar.rm.datasource.sql.struct.TableMeta;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author guoyao
+ * @date 2019/3/21
+ */
+public class InsertExecutorTest {
+
+    private static final String ID_COLUMN = "id";
+    private static final String USER_ID_COLUMN = "user_id";
+    private static final String USER_NAME_COLUMN = "user_name";
+    private static final Integer PK_VALUE = 100;
+
+    private PreparedStatementProxy statementProxy;
+
+    private SQLInsertRecognizer sqlInsertRecognizer;
+
+    private StatementCallback statementCallback;
+
+    private TableMeta tableMeta;
+
+    private InsertExecutor insertExecutor;
+
+    @Before
+    public void init() {
+        statementProxy = mock(PreparedStatementProxy.class);
+        statementCallback = mock(StatementCallback.class);
+        sqlInsertRecognizer = mock(SQLInsertRecognizer.class);
+        tableMeta =  mock(TableMeta.class);
+        insertExecutor = spy(new InsertExecutor(statementProxy, statementCallback, sqlInsertRecognizer));
+    }
+
+    @Test
+    public void testContainsPK() {
+        List<String> insertColumns=mockInsertColumns();
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        when(tableMeta.containsPK(insertColumns)).thenReturn(true);
+        Assertions.assertThat(insertExecutor.containsPK()).isTrue();
+        when(tableMeta.containsPK(insertColumns)).thenReturn(false);
+        Assertions.assertThat(insertExecutor.containsPK()).isFalse();
+    }
+
+    @Test
+    public void testGetPkValuesByColumn() throws SQLException {
+        mockInsertColumns();
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        when(tableMeta.getPkName()).thenReturn(ID_COLUMN);
+        List<Object> pkValues = new ArrayList<>();
+        pkValues.add(PK_VALUE);
+        when(statementProxy.getParamsByIndex(0)).thenReturn(pkValues);
+        List pkValuesByColumn=insertExecutor.getPkValuesByColumn();
+        Assertions.assertThat(pkValuesByColumn).isEqualTo(pkValues);
+    }
+
+    @Test(expected =ShouldNeverHappenException.class)
+    public void testGetPkValuesByColumn_Exception() throws SQLException {
+        mockInsertColumns();
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        when(tableMeta.getPkName()).thenReturn(ID_COLUMN);
+        when(statementProxy.getParamsByIndex(0)).thenReturn(null);
+        insertExecutor.getPkValuesByColumn();
+    }
+
+    @Test
+    public void testGetPkValuesByColumn_PkValue_Null() throws SQLException {
+        mockInsertColumns();
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        when(tableMeta.getPkName()).thenReturn(ID_COLUMN);
+        List<Object> pkValuesNull = new ArrayList<>();
+        pkValuesNull.add(Null.get());
+        when(statementProxy.getParamsByIndex(0)).thenReturn(pkValuesNull);
+        List<Object> pkValuesAuto = new ArrayList<>();
+        pkValuesAuto.add(PK_VALUE);
+        //mock getPkValuesByAuto
+        doReturn(pkValuesAuto).when(insertExecutor).getPkValuesByAuto();
+        List pkValuesByColumn=insertExecutor.getPkValuesByColumn();
+        //pk value = Null so getPkValuesByAuto
+        verify(insertExecutor).getPkValuesByAuto();
+        Assertions.assertThat(pkValuesByColumn).isEqualTo(pkValuesAuto);
+    }
+
+    private List<String> mockInsertColumns() {
+        List<String> columns = new ArrayList<>();
+        columns.add(ID_COLUMN);
+        columns.add(USER_ID_COLUMN);
+        columns.add(USER_NAME_COLUMN);
+        when(sqlInsertRecognizer.getInsertColumns()).thenReturn(columns);
+        return columns;
+    }
+}

--- a/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
+++ b/rm-datasource/src/test/java/com/alibaba/fescar/rm/datasource/exec/InsertExecutorTest.java
@@ -1,19 +1,43 @@
+/*
+ *  Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.alibaba.fescar.rm.datasource.exec;
 
+import com.alibaba.fescar.common.exception.NotSupportYetException;
 import com.alibaba.fescar.common.exception.ShouldNeverHappenException;
 import com.alibaba.fescar.rm.datasource.PreparedStatementProxy;
 import com.alibaba.fescar.rm.datasource.sql.SQLInsertRecognizer;
-import com.alibaba.fescar.rm.datasource.sql.struct.Null;
-import com.alibaba.fescar.rm.datasource.sql.struct.TableMeta;
+import com.alibaba.fescar.rm.datasource.sql.struct.*;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.anyString;
 
 /**
  * @author guoyao
@@ -46,8 +70,60 @@ public class InsertExecutorTest {
     }
 
     @Test
+    public void testBeforeImage() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        TableRecords tableRecords = insertExecutor.beforeImage();
+        Assertions.assertThat(tableRecords.getRows()).isEmpty();
+        Assertions.assertThat(tableRecords.size()).isEqualTo(0);
+        try {
+            tableRecords.add(new Row());
+        } catch (Exception e) {
+            Assertions.assertThat(e instanceof UnsupportedOperationException).isTrue();
+        }
+        try {
+            tableRecords.getTableMeta();
+        } catch (Exception e) {
+            Assertions.assertThat(e instanceof UnsupportedOperationException).isTrue();
+        }
+    }
+
+    @Test
+    public void testAfterImage_ByColumn() throws SQLException {
+        doReturn(true).when(insertExecutor).containsPK();
+        List<Object> pkValues = new ArrayList<>();
+        pkValues.add(PK_VALUE);
+        doReturn(pkValues).when(insertExecutor).getPkValuesByColumn();
+        TableRecords tableRecords = new TableRecords();
+        doReturn(tableRecords).when(insertExecutor).getTableRecords(pkValues);
+        TableRecords resultTableRecords = insertExecutor.afterImage(new TableRecords());
+        Assertions.assertThat(resultTableRecords).isEqualTo(tableRecords);
+    }
+
+    @Test
+    public void testAfterImage_ByAuto() throws SQLException {
+        doReturn(false).when(insertExecutor).containsPK();
+        List<Object> pkValues = new ArrayList<>();
+        pkValues.add(PK_VALUE);
+        doReturn(pkValues).when(insertExecutor).getPkValuesByAuto();
+        TableRecords tableRecords = new TableRecords();
+        doReturn(tableRecords).when(insertExecutor).getTableRecords(pkValues);
+        TableRecords resultTableRecords = insertExecutor.afterImage(new TableRecords());
+        Assertions.assertThat(resultTableRecords).isEqualTo(tableRecords);
+    }
+
+    @Test(expected=SQLException.class)
+    public void testAfterImage_Exception() throws SQLException {
+        doReturn(false).when(insertExecutor).containsPK();
+        List<Object> pkValues = new ArrayList<>();
+        pkValues.add(PK_VALUE);
+        doReturn(pkValues).when(insertExecutor).getPkValuesByAuto();
+        doReturn(null).when(insertExecutor).getTableRecords(pkValues);
+        insertExecutor.afterImage(new TableRecords());
+    }
+
+    @Test
     public void testContainsPK() {
-        List<String> insertColumns=mockInsertColumns();
+        List<String> insertColumns = mockInsertColumns();
         doReturn(tableMeta).when(insertExecutor).getTableMeta();
         when(tableMeta.containsPK(insertColumns)).thenReturn(true);
         Assertions.assertThat(insertExecutor.containsPK()).isTrue();
@@ -88,10 +164,104 @@ public class InsertExecutorTest {
         pkValuesAuto.add(PK_VALUE);
         //mock getPkValuesByAuto
         doReturn(pkValuesAuto).when(insertExecutor).getPkValuesByAuto();
-        List pkValuesByColumn=insertExecutor.getPkValuesByColumn();
+        List pkValuesByColumn = insertExecutor.getPkValuesByColumn();
         //pk value = Null so getPkValuesByAuto
         verify(insertExecutor).getPkValuesByAuto();
         Assertions.assertThat(pkValuesByColumn).isEqualTo(pkValuesAuto);
+    }
+
+    @Test(expected =NotSupportYetException.class)
+    public void testGetPkValuesByAuto_NotSupportYetException() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
+        columnMetaMap.put(ID_COLUMN, new ColumnMeta());
+        columnMetaMap.put(USER_ID_COLUMN, new ColumnMeta());
+        when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
+        insertExecutor.getPkValuesByAuto();
+    }
+
+    @Test(expected =ShouldNeverHappenException.class)
+    public void testGetPkValuesByAuto_ShouldNeverHappenException() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
+        ColumnMeta columnMeta = mock(ColumnMeta.class);
+        columnMetaMap.put(ID_COLUMN, columnMeta);
+        when(columnMeta.isAutoincrement()).thenReturn(false);
+        when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
+        insertExecutor.getPkValuesByAuto();
+    }
+
+    @Test(expected = SQLException.class)
+    public void testGetPkValuesByAuto_SQLException() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        ColumnMeta columnMeta = mock(ColumnMeta.class);
+        Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
+        columnMetaMap.put(ID_COLUMN, columnMeta);
+        when(columnMeta.isAutoincrement()).thenReturn(true);
+        when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
+        when(preparedStatement.getGeneratedKeys()).thenThrow(new SQLException());
+        insertExecutor.getPkValuesByAuto();
+    }
+
+    @Test
+    public void testGetPkValuesByAuto_GeneratedKeys_NoResult() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        ColumnMeta columnMeta = mock(ColumnMeta.class);
+        Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
+        columnMetaMap.put(ID_COLUMN, columnMeta);
+        when(columnMeta.isAutoincrement()).thenReturn(true);
+        when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
+        ResultSet resultSet=mock(ResultSet.class);
+        when(preparedStatement.getGeneratedKeys()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
+        when(resultSet.getObject(1)).thenReturn(PK_VALUE);
+        List pkValuesByAuto=insertExecutor.getPkValuesByAuto();
+        Assertions.assertThat(pkValuesByAuto).isEmpty();
+    }
+
+    @Test
+    public void testGetPkValuesByAuto_GeneratedKeys_HasResult() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        ColumnMeta columnMeta = mock(ColumnMeta.class);
+        Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
+        columnMetaMap.put(ID_COLUMN, columnMeta);
+        when(columnMeta.isAutoincrement()).thenReturn(true);
+        when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
+        ResultSet resultSet=mock(ResultSet.class);
+        when(preparedStatement.getGeneratedKeys()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
+        when(resultSet.getObject(1)).thenReturn(PK_VALUE);
+        List<Object> pkValues = new ArrayList<>();
+        pkValues.add(PK_VALUE);
+        List pkValuesByAuto=insertExecutor.getPkValuesByAuto();
+        Assertions.assertThat(pkValuesByAuto).isEqualTo(pkValues);
+    }
+
+    @Test
+    public void testGetPkValuesByAuto_ExecuteQuery_HasResult() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        ColumnMeta columnMeta = mock(ColumnMeta.class);
+        Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
+        columnMetaMap.put(ID_COLUMN, columnMeta);
+        when(columnMeta.isAutoincrement()).thenReturn(true);
+        when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
+        when(preparedStatement.getGeneratedKeys()).thenThrow(new SQLException("", InsertExecutor.ERR_SQL_STATE));
+        ResultSet resultSet=mock(ResultSet.class);
+        when(preparedStatement.executeQuery(anyString())).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true).thenReturn(false);
+        when(resultSet.getObject(1)).thenReturn(PK_VALUE);
+        List<Object> pkValues = new ArrayList<>();
+        pkValues.add(PK_VALUE);
+        List pkValuesByAuto=insertExecutor.getPkValuesByAuto();
+        Assertions.assertThat(pkValuesByAuto).isEqualTo(pkValues);
     }
 
     private List<String> mockInsertColumns() {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
when pk auto generated and  value is null, fescar can not get the pk value .

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fix #357 
### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

