### PR TITLE
fix: RedisRegistry's problems

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingServer.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingServer.java
@@ -171,7 +171,7 @@ public abstract class AbstractRpcRemotingServer extends AbstractRpcRemoting impl
     public void shutdown() {
         try {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Start to shutdown server. ");
+                LOGGER.debug("Shuting server down. ");
             }
             RegistryFactory.getInstance().unregister(new InetSocketAddress(XID.getIpAddress(), XID.getPort()));
             //wait a few seconds for server transport

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingServer.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingServer.java
@@ -18,6 +18,7 @@ package com.alibaba.fescar.core.rpc.netty;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import com.alibaba.fescar.common.XID;
 import com.alibaba.fescar.common.thread.NamedThreadFactory;
@@ -159,7 +160,7 @@ public abstract class AbstractRpcRemotingServer extends AbstractRpcRemoting impl
     }
 
     /**
-     * regiter vm shutdown hook for graceful shutdown
+     * Register vm shutdown hook to shutdown gracefully
      * can't prevent kill -9
      */
     private void registerShutdownHook() {
@@ -169,10 +170,12 @@ public abstract class AbstractRpcRemotingServer extends AbstractRpcRemoting impl
     @Override
     public void shutdown() {
         try {
-            LOGGER.info("Server shutdown ... ");
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Start to shutdown server. ");
+            }
             RegistryFactory.getInstance().unregister(new InetSocketAddress(XID.getIpAddress(), XID.getPort()));
             //wait a few seconds for server transport
-            Thread.sleep(nettyServerConfig.getServerShutdownWaitTime());
+            TimeUnit.SECONDS.sleep(nettyServerConfig.getServerShutdownWaitTime());
 
             this.eventLoopGroupBoss.shutdownGracefully();
             this.eventLoopGroupWorker.shutdownGracefully();

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyServerConfig.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyServerConfig.java
@@ -47,9 +47,10 @@ public class NettyServerConfig extends NettyBaseConfig {
     private static final int DEFAULT_BOSS_THREAD_SIZE = 1;
 
     /**
-     * default 1000ms
+     * Shutdown timeout default 1s
      */
-    private static final int DEFAULT_SHUTDOWN_WAIT = 1000;
+    private static final int DEFAULT_SHUTDOWN_TIMEOUT_SEC = 1;
+
     /**
      * The Server channel clazz.
      */
@@ -300,12 +301,13 @@ public class NettyServerConfig extends NettyBaseConfig {
     public int getBossThreadSize() {
         return CONFIG.getInt("transport.thread-factory.boss-thread-size", DEFAULT_BOSS_THREAD_SIZE);
     }
+
     /**
-     * Get shutdown Timeout.
+     * Get the timeout seconds of shutdown.
      *
      * @return the int
      */
     public int getServerShutdownWaitTime() {
-        return CONFIG.getInt("transport.shutdown.wait", DEFAULT_SHUTDOWN_WAIT);
+        return CONFIG.getInt("transport.shutdown.wait", DEFAULT_SHUTDOWN_TIMEOUT_SEC);
     }
 }

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyServerConfig.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyServerConfig.java
@@ -45,6 +45,11 @@ public class NettyServerConfig extends NettyBaseConfig {
     private static final String NIO_WORKER_THREAD_PREFIX = "NettyServerNIOWorker";
     private static final String DEFAULT_EXECUTOR_THREAD_PREFIX = "NettyServerBizHandler";
     private static final int DEFAULT_BOSS_THREAD_SIZE = 1;
+
+    /**
+     * default 1000ms
+     */
+    private static final int DEFAULT_SHUTDOWN_WAIT = 1000;
     /**
      * The Server channel clazz.
      */
@@ -295,5 +300,12 @@ public class NettyServerConfig extends NettyBaseConfig {
     public int getBossThreadSize() {
         return CONFIG.getInt("transport.thread-factory.boss-thread-size", DEFAULT_BOSS_THREAD_SIZE);
     }
-
+    /**
+     * Get shutdown Timeout.
+     *
+     * @return the int
+     */
+    public int getServerShutdownWaitTime() {
+        return CONFIG.getInt("transport.shutdown.wait", DEFAULT_SHUTDOWN_WAIT);
+    }
 }

--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/RedisRegistryServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/RedisRegistryServiceImpl.java
@@ -146,19 +146,9 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
         try {
             jedis.hset(getRedisRegistryKey(), serverAddr, ManagementFactory.getRuntimeMXBean().getName());
             jedis.publish(getRedisRegistryKey(), serverAddr + "-" + RedisListener.REGISTER);
-            // it can't prevent kill -9
-            registerShutdownHook(address);
         } finally {
             jedis.close();
         }
-    }
-
-    /**
-     * register vm shutdownHook
-     * @param address
-     */
-    private void registerShutdownHook(InetSocketAddress address) {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> unregister(address)));
     }
 
     @Override


### PR DESCRIPTION
1. modify the FileConfiguration in the RedisRegistry.Let it use registry.conf
2. fix uese redis registry, if restart or close the redis coudn't unregister the server.But still can't prevent kill -9.

the second commit ：
Add shutdownHook, For graceful shutdown.
this can replace the shutdownHook in the RedisRegistry.Another benefit is that the shutdown code is unified

