### PR TITLE
fix #647 uses IP address to register or unregister to Nacos

### DIFF
--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/NacosRegistryServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/NacosRegistryServiceImpl.java
@@ -119,7 +119,7 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
         }
         if (!LISTENER_SERVICE_MAP.containsKey(clusterName)) {
             List<String> clusters = new ArrayList<>();
-            clusters.add(getClusterName());
+            clusters.add(clusterName);
             List<Instance> firstAllInstances = getNamingInstance().getAllInstances(PRO_SERVER_ADDR_KEY, clusters);
             if (null != firstAllInstances) {
                 List<InetSocketAddress> newAddressList = new ArrayList<>();

--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/NacosRegistryServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/NacosRegistryServiceImpl.java
@@ -41,7 +41,6 @@ import com.alibaba.nacos.client.naming.utils.CollectionUtils;
  * @date 2019 /1/31
  */
 public class NacosRegistryServiceImpl implements RegistryService<EventListener> {
-
     private static final String DEFAULT_NAMESPACE = "public";
     private static final String DEFAULT_CLUSTER = "default";
     private static final String PRO_SERVER_ADDR_KEY = "serverAddr";
@@ -54,7 +53,8 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
     private static final ConcurrentMap<String, List<InetSocketAddress>> CLUSTER_ADDRESS_MAP = new ConcurrentHashMap<>();
     private static volatile NacosRegistryServiceImpl instance;
 
-    private NacosRegistryServiceImpl() {}
+    private NacosRegistryServiceImpl() {
+    }
 
     /**
      * Gets instance.
@@ -75,15 +75,13 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
     @Override
     public void register(InetSocketAddress address) throws Exception {
         validAddress(address);
-        getNamingInstance().registerInstance(PRO_SERVER_ADDR_KEY, address.getHostName(), address.getPort(),
-            getClusterName());
+        getNamingInstance().registerInstance(PRO_SERVER_ADDR_KEY, address.getAddress().getHostAddress(), address.getPort(), getClusterName());
     }
 
     @Override
     public void unregister(InetSocketAddress address) throws Exception {
         validAddress(address);
-        getNamingInstance().deregisterInstance(PRO_SERVER_ADDR_KEY, address.getHostName(), address.getPort(),
-            getClusterName());
+        getNamingInstance().deregisterInstance(PRO_SERVER_ADDR_KEY, address.getAddress().getHostAddress(), address.getPort(), getClusterName());
     }
 
     @Override
@@ -121,7 +119,7 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
         }
         if (!LISTENER_SERVICE_MAP.containsKey(clusterName)) {
             List<String> clusters = new ArrayList<>();
-            clusters.add(clusterName);
+            clusters.add(getClusterName());
             List<Instance> firstAllInstances = getNamingInstance().getAllInstances(PRO_SERVER_ADDR_KEY, clusters);
             if (null != firstAllInstances) {
                 List<InetSocketAddress> newAddressList = new ArrayList<>();
@@ -135,7 +133,7 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
             subscribe(clusterName, new EventListener() {
                 @Override
                 public void onEvent(Event event) {
-                    List<Instance> instances = ((NamingEvent)event).getInstances();
+                    List<Instance> instances = ((NamingEvent) event).getInstances();
                     if (null == instances && null != CLUSTER_ADDRESS_MAP.get(clusterName)) {
                         CLUSTER_ADDRESS_MAP.remove(clusterName);
                     } else if (!CollectionUtils.isEmpty(instances)) {
@@ -208,19 +206,19 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
 
     private static String getNacosAddrFileKey() {
         return ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + REGISTRY_TYPE
-            + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
-            + PRO_SERVER_ADDR_KEY;
+                + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+                + PRO_SERVER_ADDR_KEY;
     }
 
     private static String getNacosNameSpaceFileKey() {
         return ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + REGISTRY_TYPE
-            + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
-            + PRO_NAMESPACE_KEY;
+                + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+                + PRO_NAMESPACE_KEY;
     }
 
     private static String getNacosClusterFileKey() {
         return ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + REGISTRY_TYPE
-            + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
-            + REGISTRY_CLUSTER;
+                + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+                + REGISTRY_CLUSTER;
     }
 }

--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/NacosRegistryServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/NacosRegistryServiceImpl.java
@@ -206,19 +206,19 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
 
     private static String getNacosAddrFileKey() {
         return ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + REGISTRY_TYPE
-                + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
-                + PRO_SERVER_ADDR_KEY;
+            + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+            + PRO_SERVER_ADDR_KEY;
     }
 
     private static String getNacosNameSpaceFileKey() {
         return ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + REGISTRY_TYPE
-                + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
-                + PRO_NAMESPACE_KEY;
+            + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+            + PRO_NAMESPACE_KEY;
     }
 
     private static String getNacosClusterFileKey() {
         return ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + REGISTRY_TYPE
-                + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
-                + REGISTRY_CLUSTER;
+            + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+            + REGISTRY_CLUSTER;
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
when use Nacos as our discovery service,
we should always use IP address instead of Hostname to register or unregister to Nacos.otherwise,you will get the following exceptions:
`01 2019-03-29 09:42:21.164 ERROR [main :c.a.n.c.naming] [] [] [CALL-SERVER] failed to req API:http://localhost:8848/nacos/v1/ns/instance. code:400 msg: instance format invalid:CHINA-20181022Z:8091:unknown:default_1.0_true_false_default
01 2019-03-29 09:42:21.166 ERROR [main :c.a.n.c.naming] [] [] [NA] req api:/nacos/v1/ns/instance failed, server(localhost
com.alibaba.nacos.api.exception.NacosException: null
	at com.alibaba.nacos.client.naming.net.NamingProxy.callServer(NamingProxy.java:333)
	at com.alibaba.nacos.client.naming.net.NamingProxy.reqAPI(NamingProxy.java:358)
	at com.alibaba.nacos.client.naming.net.NamingProxy.reqAPI(NamingProxy.java:290)
	at com.alibaba.nacos.client.naming.net.NamingProxy.registerService(NamingProxy.java:175)
	at com.alibaba.nacos.client.naming.NacosNamingService.registerInstance(NacosNamingService.java:178)
	at com.alibaba.nacos.client.naming.NacosNamingService.registerInstance(NacosNamingService.java:161)
	at com.alibaba.fescar.discovery.registry.NacosRegistryServiceImpl.register(NacosRegistryServiceImpl.java:78)
	at com.alibaba.fescar.core.rpc.netty.AbstractRpcRemotingServer.start(AbstractRpcRemotingServer.java:153)
	at com.alibaba.fescar.core.rpc.netty.RpcServer.init(RpcServer.java:130)
	at com.alibaba.fescar.server.Server.main(Server.java:88)`

Perhaps Nacos only supports IP addresses to register or deregister a instance.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
#647

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
I've done integration testing with our samples.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

