### PR TITLE
add: recycle buffer

### DIFF
--- a/server/src/main/java/com/alibaba/fescar/server/session/BranchSession.java
+++ b/server/src/main/java/com/alibaba/fescar/server/session/BranchSession.java
@@ -33,6 +33,8 @@ import com.alibaba.fescar.server.store.SessionStorable;
  */
 public class BranchSession implements Lockable, Comparable<BranchSession>, SessionStorable {
 
+    private static ThreadLocal<ByteBuffer> byteBufferThreadLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocate(2048));
+
     private long transactionId;
 
     private long branchId;
@@ -268,7 +270,10 @@ public class BranchSession implements Lockable, Comparable<BranchSession>, Sessi
 
     @Override
     public byte[] encode() {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(2048);
+        ByteBuffer byteBuffer = byteBufferThreadLocal.get();
+        //recycle
+        byteBuffer.clear();
+
         byteBuffer.putLong(transactionId);
         byteBuffer.putLong(branchId);
         if (null != resourceId) {

--- a/server/src/main/java/com/alibaba/fescar/server/session/BranchSession.java
+++ b/server/src/main/java/com/alibaba/fescar/server/session/BranchSession.java
@@ -33,7 +33,9 @@ import com.alibaba.fescar.server.store.SessionStorable;
  */
 public class BranchSession implements Lockable, Comparable<BranchSession>, SessionStorable {
 
-    private static ThreadLocal<ByteBuffer> byteBufferThreadLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocate(2048));
+    public static final int DEFAULT_BRANCH_SESSION_BUFFER_SIZE = 2048;
+
+    private static ThreadLocal<ByteBuffer> byteBufferThreadLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocate(DEFAULT_BRANCH_SESSION_BUFFER_SIZE));
 
     private long transactionId;
 

--- a/server/src/main/java/com/alibaba/fescar/server/session/GlobalSession.java
+++ b/server/src/main/java/com/alibaba/fescar/server/session/GlobalSession.java
@@ -32,6 +32,8 @@ import com.alibaba.fescar.server.store.SessionStorable;
  */
 public class GlobalSession implements SessionLifecycle, SessionStorable {
 
+    private static ThreadLocal<ByteBuffer> byteBufferThreadLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocate(512));
+
     private long transactionId;
 
     private GlobalStatus status;
@@ -366,7 +368,10 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
 
     @Override
     public byte[] encode() {
-        ByteBuffer byteBuffer = ByteBuffer.allocate(512);
+        ByteBuffer byteBuffer = byteBufferThreadLocal.get();
+        //recycle
+        byteBuffer.clear();
+
         byteBuffer.putLong(transactionId);
         byteBuffer.putInt(timeout);
         if (null != applicationId) {

--- a/server/src/main/java/com/alibaba/fescar/server/session/GlobalSession.java
+++ b/server/src/main/java/com/alibaba/fescar/server/session/GlobalSession.java
@@ -32,7 +32,9 @@ import com.alibaba.fescar.server.store.SessionStorable;
  */
 public class GlobalSession implements SessionLifecycle, SessionStorable {
 
-    private static ThreadLocal<ByteBuffer> byteBufferThreadLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocate(512));
+    public static final int DEFAULT_GLOBAL_SESSION_BUFFER_SIZE = 512;
+
+    private static ThreadLocal<ByteBuffer> byteBufferThreadLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocate(DEFAULT_GLOBAL_SESSION_BUFFER_SIZE));
 
     private long transactionId;
 

--- a/server/src/main/java/com/alibaba/fescar/server/store/FileTransactionStoreManager.java
+++ b/server/src/main/java/com/alibaba/fescar/server/store/FileTransactionStoreManager.java
@@ -262,7 +262,9 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
      */
     class WriteDataFileRunnable implements Runnable {
 
-        private ThreadLocal<ByteBuffer> writeBufferLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocateDirect(4096));
+        public static final int DEFAULT_WRITE_BUFFER_SIZE = 4096;
+
+        ByteBuffer wireteBuffer =  ByteBuffer.allocateDirect(DEFAULT_WRITE_BUFFER_SIZE);
 
         @Override
         public void run() {
@@ -301,7 +303,7 @@ public class FileTransactionStoreManager implements TransactionStoreManager {
 
         private boolean writeDataFile(byte[] bs) {
             int retry = 0;
-            ByteBuffer byteBuffer = writeBufferLocal.get();
+            ByteBuffer byteBuffer = wireteBuffer;
             //recycle
             byteBuffer.clear();
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

In the code, there are many bytebuffers created but not reused. To reduce the number of YGC, ByteBuffer is reused.

I first read netty's recycle and implemented it. But this is a big change and will make the byte[] that was previously returned by SessionStorable into one of our custom objects, so I dropped it.

Then I looked at other store's system, such as RocketMq, which use ThreadLocal for caching,.it is simple and has very little momentum.

I ran the write part of WriteStoreTest, the VM parameter was -Xmx10m, the YGC was 3,400 times before the modification, and the YGC was 900 times after the modification.

I also changed the HeapByteBuffer used by Filechannel to DirectHeapByteBuffer.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
run write part of WriteStoreTest, VM parameter -Xmx10m
wathching jstat -gc pid 1000

### Ⅴ. Special notes for reviews

